### PR TITLE
Correct unable to backspace on last digit for gas price

### DIFF
--- a/src/modals/SendModal/TransactionForm.tsx
+++ b/src/modals/SendModal/TransactionForm.tsx
@@ -192,7 +192,7 @@ const onAmountInputValueChange = ({
   let amountNumber
 
   try {
-    amountNumber = shouldConvertToSet ? convertAlphToSet(amount) : BigInt(amount)
+    amountNumber = shouldConvertToSet ? convertAlphToSet(amount || '0') : BigInt(amount)
   } catch (e) {
     console.log(e)
     return


### PR DESCRIPTION
This particular value is auto-converted to set, as `shouldConvertToSet` is true,
so the `convertAlphToSet` function is called, but isn't valid to pass it an
empty string, so the error prevents the final input from occuring.

The fix passes '0' instead to the function when it's a falsy value.