### PR TITLE
Add ability to restore wallets which use less than 24 word mnemonics

### DIFF
--- a/src/modals/AccountRemovalModal.tsx
+++ b/src/modals/AccountRemovalModal.tsx
@@ -42,7 +42,7 @@ const AccountRemovalModal = ({ accountName, onAccountRemove, onClose }: AccountR
       <Section>
         <InfoBox
           importance="alert"
-          text="Please make sure to have your secret phrase saved and stored somewhere secure to restore your wallet in the future. Without the 24 words, your wallet will be unrecoverable and permanently lost."
+          text="Please make sure to have your secret phrase saved and stored somewhere secure to restore your wallet in the future. Without the secret phrase, your wallet will be unrecoverable and permanently lost."
         />
         <Paragraph secondary centered>
           <b>Not your keys, not your coins.</b>

--- a/src/modals/SecretPhraseModal.tsx
+++ b/src/modals/SecretPhraseModal.tsx
@@ -35,7 +35,7 @@ const SecretPhraseModal = ({ onClose }: { onClose: () => void }) => {
       {!isDisplayingPhrase ? (
         <div>
           <PasswordConfirmation
-            text="Type your password above to show your 24 words phrase."
+            text="Type your password above to show your secret phrase."
             buttonText="Show"
             onCorrectPasswordEntered={() => setIsDisplayingPhrase(true)}
           />
@@ -43,11 +43,11 @@ const SecretPhraseModal = ({ onClose }: { onClose: () => void }) => {
       ) : (
         <Section>
           <InfoBox
-            text={'Carefully note down the 24 words. They are the keys to your wallet.'}
+            text={'Carefully note down the words! They are the secret keys to your wallet.'}
             Icon={Edit3}
             importance="alert"
           />
-          <PhraseBox>{wallet?.mnemonic || 'No mnemonic was stored along with this wallet'}</PhraseBox>
+          <PhraseBox>{wallet?.mnemonic || 'No secret phrase was stored along with this wallet'}</PhraseBox>
         </Section>
       )}
     </CenteredModal>

--- a/src/pages/WalletManagement/ImportWordsPage.tsx
+++ b/src/pages/WalletManagement/ImportWordsPage.tsx
@@ -45,7 +45,7 @@ const ImportWordsPage = () => {
 
   const [phrase, setPhrase] = useState<{ value: string }[]>([])
   const allowedWords = useRef(bip39Words.split(' '))
-  const defaultPlaceholder = 'Type your 24 words'
+  const defaultPlaceholder = 'Type your secret phrase'
   const [customPlaceholder, setCustomPlaceholder] = useState(defaultPlaceholder)
   const tagifyRef = useRef<Tagify<TagData> | undefined>()
 
@@ -53,9 +53,7 @@ const ImportWordsPage = () => {
     // Split words where spaces are
     const newPhrase = event.detail.value && JSON.parse(event.detail.value)
     setPhrase(newPhrase || [])
-    setCustomPlaceholder(
-      newPhrase.length > 0 ? (newPhrase.length === 24 ? '' : `${24 - newPhrase.length} words left`) : defaultPlaceholder
-    )
+    setCustomPlaceholder(newPhrase.length > 0 ? `${newPhrase.length} words entered` : defaultPlaceholder)
   }
 
   useEffect(() => {
@@ -84,7 +82,8 @@ const ImportWordsPage = () => {
     }
   }
 
-  const isNextButtonActive = phrase.length === 24
+  // Alephium's node code uses 12 as the minimal mnemomic length.
+  const isNextButtonActive = phrase.length >= 12
 
   return (
     <FloatingPanel>
@@ -100,7 +99,7 @@ const ImportWordsPage = () => {
         </Section>
         <Paragraph secondary centered>
           {!isNextButtonActive
-            ? 'Make sure to properly write down the 24 words from your secret phrase. They are the key to your wallet.'
+            ? 'Make sure to properly write down the words in a secure location! They are the secret key to your wallet.'
             : "All good? Let's continue!"}
         </Paragraph>
       </PanelContentContainer>

--- a/src/pages/WalletManagement/WalletWordsPage.tsx
+++ b/src/pages/WalletManagement/WalletWordsPage.tsx
@@ -85,7 +85,7 @@ const WalletWordsPage = () => {
           <Label>Secret phrase</Label>
           <PhraseBox>{renderFormatedMnemonic(mnemonic)}</PhraseBox>
           <InfoBox
-            text={'Carefully note down the 24 words. They are the keys to your wallet.'}
+            text={'Carefully note down the words! They are the secret keys to your wallet.'}
             Icon={Edit3}
             importance="alert"
           />


### PR DESCRIPTION
The desktop-wallet made an assumption that all wallets will use 24 word
mnemonics but the Alephium node allows between 12 and 24 word mnemonics, so
some miners or node users are unable to import their wallets into the desktop-
wallet software.

This commit also cleans up the language around "24 words" and "secret phrase",
making it more consistent.

Resolves https://github.com/alephium/desktop-wallet/issues/172