### PR TITLE
Upgrade electron-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "cross-env": "^7.0.3",
         "dayjs": "^1.10.7",
         "electron": "^15.0.0",
-        "electron-builder": "^22.13.1",
+        "electron-builder": "^23.0.3",
         "electron-devtools-installer": "^3.2.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-header": "^3.1.1",
@@ -2423,16 +2423,18 @@
       }
     },
     "node_modules/@electron/universal": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.5.tgz",
-      "integrity": "sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.0.tgz",
+      "integrity": "sha512-eu20BwNsrMPKoe2bZ3/l9c78LclDvxg3PlVXrQf3L50NaUuW5M59gbPytI+V4z7/QMrohUHetQaU0ou+p1UG9Q==",
       "dev": true,
       "dependencies": {
         "@malept/cross-spawn-promise": "^1.1.0",
-        "asar": "^3.0.3",
+        "asar": "^3.1.0",
         "debug": "^4.3.1",
         "dir-compare": "^2.4.0",
-        "fs-extra": "^9.0.1"
+        "fs-extra": "^9.0.1",
+        "minimatch": "^3.0.4",
+        "plist": "^3.0.4"
       },
       "engines": {
         "node": ">=8.6"
@@ -6479,30 +6481,30 @@
       }
     },
     "node_modules/app-builder-bin": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.7.1.tgz",
-      "integrity": "sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
       "dev": true
     },
     "node_modules/app-builder-lib": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.14.5.tgz",
-      "integrity": "sha512-k3VwKP4kpsnUaXoUkm1s4zaSHPHIMFnN4kPMU9yXaKmE1LfHHqBaEah5bXeTAX5V/BC41wFdg8CF5vOjvgy8Rg==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.3.tgz",
+      "integrity": "sha512-1qrtXYHXJfXhzJnMtVGjIva3067F1qYQubl2oBjI61gCBoCHvhghdYJ57XxXTQQ0VxnUhg1/Iaez87uXp8mD8w==",
       "dev": true,
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
-        "@electron/universal": "1.0.5",
+        "@electron/universal": "1.2.0",
         "@malept/flatpak-bundler": "^0.4.0",
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.14.5",
-        "builder-util-runtime": "8.9.1",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.2",
         "ejs": "^3.1.6",
-        "electron-osx-sign": "^0.5.0",
-        "electron-publish": "22.14.5",
+        "electron-osx-sign": "^0.6.0",
+        "electron-publish": "23.0.2",
         "form-data": "^4.0.0",
         "fs-extra": "^10.0.0",
         "hosted-git-info": "^4.0.2",
@@ -6521,9 +6523,9 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6546,19 +6548,28 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/app-builder-lib/node_modules/lru-cache": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+      "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/app-builder-lib/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+      "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^6.0.0"
+        "lru-cache": "^7.4.0"
       },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/app-builder-lib/node_modules/universalify": {
@@ -8423,21 +8434,23 @@
       "dev": true
     },
     "node_modules/builder-util": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.14.5.tgz",
-      "integrity": "sha512-zqIHDFJwmA7jV7SC9aI+33MWwT2mWoijH+Ol9IntNAwuuRXoS+7XeJwnhLBXOhcDBzXT4kDzHnRk4JKeaygEYA==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.2.tgz",
+      "integrity": "sha512-HaNHL3axNW/Ms8O1mDx3I07G+ZnZ/TKSWWvorOAPau128cdt9S+lNx5ocbx8deSaHHX4WFXSZVHh3mxlaKJNgg==",
       "dev": true,
       "dependencies": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
         "7zip-bin": "~5.1.1",
-        "app-builder-bin": "3.7.1",
+        "app-builder-bin": "4.0.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.9.1",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.2",
         "fs-extra": "^10.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
         "is-ci": "^3.0.0",
         "js-yaml": "^4.1.0",
         "source-map-support": "^0.5.19",
@@ -8446,9 +8459,9 @@
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz",
-      "integrity": "sha512-c8a8J3wK6BIVLW7ls+7TRK9igspTbzWmUqxFbgK0m40Ggm6efUbxtWVCGIjc+dtchyr5qAMAUL6iEGRdS/6vwg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.0.tgz",
+      "integrity": "sha512-SkpEtSmTkREDHRJnxKEv43aAYp8sYWY8fxYBhGLBLOBIRXeaIp6Kv3lBgSD7uR8jQtC7CA659sqJrpSV6zNvSA==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.2",
@@ -8456,6 +8469,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/builder-util/node_modules/chalk": {
@@ -8475,9 +8497,9 @@
       }
     },
     "node_modules/builder-util/node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -8486,6 +8508,20 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/builder-util/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/builder-util/node_modules/jsonfile": {
@@ -11375,14 +11411,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.5.tgz",
-      "integrity": "sha512-1GvFGQE332bvPamcMwZDqWqfWfJTyyDLOsHMcGi0zs+Jh7JOn6/zuBkHJIWHdsj2QJbhzLVyd2/ZqttOKv7I8w==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.3.tgz",
+      "integrity": "sha512-mBYrHHnSM5PC656TDE+xTGmXIuWHAGmmRfyM+dV0kP+AxtwPof4pAXNQ8COd0/exZQ4dqf72FiPS3B9G9aB5IA==",
       "dev": true,
       "dependencies": {
-        "app-builder-lib": "22.14.5",
-        "builder-util": "22.14.5",
-        "builder-util-runtime": "8.9.1",
+        "app-builder-lib": "23.0.3",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
@@ -11392,9 +11428,9 @@
       }
     },
     "node_modules/dmg-builder/node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -11427,9 +11463,10 @@
       }
     },
     "node_modules/dmg-license": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.10.tgz",
-      "integrity": "sha512-SVeeyiOeinV5JCPHXMdKOgK1YVbak/4+8WL2rBnfqRYpA5FaeFaQnQWb25x628am1w70CbipGDv9S51biph63A==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "deprecated": "Disk image license agreements are deprecated by Apple and will probably be removed in a future macOS release. Discussion at: https://github.com/argv-minus-one/dmg-license/issues/11",
       "dev": true,
       "optional": true,
       "os": [
@@ -11921,17 +11958,17 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.14.5.tgz",
-      "integrity": "sha512-N73hSbXFz6Mz5Z6h6C5ly6CB+dUN6k1LuCDJjI8VF47bMXv/QE0HE+Kkb0GPKqTqM7Hsk/yIYX+kHCfSkR5FGg==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.3.tgz",
+      "integrity": "sha512-0lnTsljAgcOMuIiOjPcoFf+WxOOe/O04hZPgIvvUBXIbz3kolbNu0Xdch1f5WuQ40NdeZI7oqs8Eo395PcuGHQ==",
       "dev": true,
       "dependencies": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "22.14.5",
-        "builder-util": "22.14.5",
-        "builder-util-runtime": "8.9.1",
+        "app-builder-lib": "23.0.3",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
-        "dmg-builder": "22.14.5",
+        "dmg-builder": "23.0.3",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -12078,9 +12115,9 @@
       }
     },
     "node_modules/electron-osx-sign": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
-      "integrity": "sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
+      "integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
       "dev": true,
       "dependencies": {
         "bluebird": "^3.5.0",
@@ -12126,14 +12163,14 @@
       "dev": true
     },
     "node_modules/electron-publish": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.14.5.tgz",
-      "integrity": "sha512-h+NANRdaA0PqGF15GKvorseWPzh1PXa/zx4I37//PIokW8eKIov8ky23foUSb55ZFWUHGpxQJux7y2NCfBtQeg==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.2.tgz",
+      "integrity": "sha512-8gMYgWqv96lc83FCm85wd+tEyxNTJQK7WKyPkNkO8GxModZqt1GO8S+/vAnFGxilS/7vsrVRXFfqiCDUCSuxEg==",
       "dev": true,
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "22.14.5",
-        "builder-util-runtime": "8.9.1",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
@@ -12157,9 +12194,9 @@
       }
     },
     "node_modules/electron-publish/node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -15639,9 +15676,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -17084,9 +17121,9 @@
       "dev": true
     },
     "node_modules/isbinaryfile": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.8.tgz",
-      "integrity": "sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
       "dev": true,
       "engines": {
         "node": ">= 8.0.0"
@@ -17212,13 +17249,13 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-      "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+      "version": "10.8.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.4.tgz",
+      "integrity": "sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==",
       "dev": true,
       "dependencies": {
         "async": "0.9.x",
-        "chalk": "^2.4.2",
+        "chalk": "^4.0.2",
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
       },
@@ -17226,78 +17263,23 @@
         "jake": "bin/cli.js"
       },
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/jake/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=10"
       }
     },
     "node_modules/jake/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/jake/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/jake/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "node_modules/jake/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/jake/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/jake/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
+        "node": ">=10"
       },
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jed": {
@@ -30196,9 +30178,9 @@
       }
     },
     "node_modules/temp-file/node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -35379,16 +35361,18 @@
       }
     },
     "@electron/universal": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.5.tgz",
-      "integrity": "sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.0.tgz",
+      "integrity": "sha512-eu20BwNsrMPKoe2bZ3/l9c78LclDvxg3PlVXrQf3L50NaUuW5M59gbPytI+V4z7/QMrohUHetQaU0ou+p1UG9Q==",
       "dev": true,
       "requires": {
         "@malept/cross-spawn-promise": "^1.1.0",
-        "asar": "^3.0.3",
+        "asar": "^3.1.0",
         "debug": "^4.3.1",
         "dir-compare": "^2.4.0",
-        "fs-extra": "^9.0.1"
+        "fs-extra": "^9.0.1",
+        "minimatch": "^3.0.4",
+        "plist": "^3.0.4"
       },
       "dependencies": {
         "fs-extra": {
@@ -38695,30 +38679,30 @@
       }
     },
     "app-builder-bin": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.7.1.tgz",
-      "integrity": "sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
       "dev": true
     },
     "app-builder-lib": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.14.5.tgz",
-      "integrity": "sha512-k3VwKP4kpsnUaXoUkm1s4zaSHPHIMFnN4kPMU9yXaKmE1LfHHqBaEah5bXeTAX5V/BC41wFdg8CF5vOjvgy8Rg==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.3.tgz",
+      "integrity": "sha512-1qrtXYHXJfXhzJnMtVGjIva3067F1qYQubl2oBjI61gCBoCHvhghdYJ57XxXTQQ0VxnUhg1/Iaez87uXp8mD8w==",
       "dev": true,
       "requires": {
         "@develar/schema-utils": "~2.6.5",
-        "@electron/universal": "1.0.5",
+        "@electron/universal": "1.2.0",
         "@malept/flatpak-bundler": "^0.4.0",
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.14.5",
-        "builder-util-runtime": "8.9.1",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.2",
         "ejs": "^3.1.6",
-        "electron-osx-sign": "^0.5.0",
-        "electron-publish": "22.14.5",
+        "electron-osx-sign": "^0.6.0",
+        "electron-publish": "23.0.2",
         "form-data": "^4.0.0",
         "fs-extra": "^10.0.0",
         "hosted-git-info": "^4.0.2",
@@ -38734,9 +38718,9 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -38754,13 +38738,19 @@
             "universalify": "^2.0.0"
           }
         },
+        "lru-cache": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+          "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
+          "dev": true
+        },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
           "dev": true,
           "requires": {
-            "lru-cache": "^6.0.0"
+            "lru-cache": "^7.4.0"
           }
         },
         "universalify": {
@@ -40328,21 +40318,23 @@
       "dev": true
     },
     "builder-util": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.14.5.tgz",
-      "integrity": "sha512-zqIHDFJwmA7jV7SC9aI+33MWwT2mWoijH+Ol9IntNAwuuRXoS+7XeJwnhLBXOhcDBzXT4kDzHnRk4JKeaygEYA==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.2.tgz",
+      "integrity": "sha512-HaNHL3axNW/Ms8O1mDx3I07G+ZnZ/TKSWWvorOAPau128cdt9S+lNx5ocbx8deSaHHX4WFXSZVHh3mxlaKJNgg==",
       "dev": true,
       "requires": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
         "7zip-bin": "~5.1.1",
-        "app-builder-bin": "3.7.1",
+        "app-builder-bin": "4.0.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.9.1",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.2",
         "fs-extra": "^10.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
         "is-ci": "^3.0.0",
         "js-yaml": "^4.1.0",
         "source-map-support": "^0.5.19",
@@ -40350,6 +40342,12 @@
         "temp-file": "^3.4.0"
       },
       "dependencies": {
+        "@tootallnate/once": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+          "dev": true
+        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -40361,14 +40359,25 @@
           }
         },
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "2",
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "jsonfile": {
@@ -40390,9 +40399,9 @@
       }
     },
     "builder-util-runtime": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz",
-      "integrity": "sha512-c8a8J3wK6BIVLW7ls+7TRK9igspTbzWmUqxFbgK0m40Ggm6efUbxtWVCGIjc+dtchyr5qAMAUL6iEGRdS/6vwg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.0.tgz",
+      "integrity": "sha512-SkpEtSmTkREDHRJnxKEv43aAYp8sYWY8fxYBhGLBLOBIRXeaIp6Kv3lBgSD7uR8jQtC7CA659sqJrpSV6zNvSA==",
       "dev": true,
       "requires": {
         "debug": "^4.3.2",
@@ -42706,14 +42715,14 @@
       }
     },
     "dmg-builder": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.5.tgz",
-      "integrity": "sha512-1GvFGQE332bvPamcMwZDqWqfWfJTyyDLOsHMcGi0zs+Jh7JOn6/zuBkHJIWHdsj2QJbhzLVyd2/ZqttOKv7I8w==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.3.tgz",
+      "integrity": "sha512-mBYrHHnSM5PC656TDE+xTGmXIuWHAGmmRfyM+dV0kP+AxtwPof4pAXNQ8COd0/exZQ4dqf72FiPS3B9G9aB5IA==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "22.14.5",
-        "builder-util": "22.14.5",
-        "builder-util-runtime": "8.9.1",
+        "app-builder-lib": "23.0.3",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "dmg-license": "^1.0.9",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
@@ -42721,9 +42730,9 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -42750,9 +42759,9 @@
       }
     },
     "dmg-license": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.10.tgz",
-      "integrity": "sha512-SVeeyiOeinV5JCPHXMdKOgK1YVbak/4+8WL2rBnfqRYpA5FaeFaQnQWb25x628am1w70CbipGDv9S51biph63A==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -43163,17 +43172,17 @@
       }
     },
     "electron-builder": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.14.5.tgz",
-      "integrity": "sha512-N73hSbXFz6Mz5Z6h6C5ly6CB+dUN6k1LuCDJjI8VF47bMXv/QE0HE+Kkb0GPKqTqM7Hsk/yIYX+kHCfSkR5FGg==",
+      "version": "23.0.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.3.tgz",
+      "integrity": "sha512-0lnTsljAgcOMuIiOjPcoFf+WxOOe/O04hZPgIvvUBXIbz3kolbNu0Xdch1f5WuQ40NdeZI7oqs8Eo395PcuGHQ==",
       "dev": true,
       "requires": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "22.14.5",
-        "builder-util": "22.14.5",
-        "builder-util-runtime": "8.9.1",
+        "app-builder-lib": "23.0.3",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
-        "dmg-builder": "22.14.5",
+        "dmg-builder": "23.0.3",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -43285,9 +43294,9 @@
       "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
     },
     "electron-osx-sign": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
-      "integrity": "sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
+      "integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
@@ -43325,14 +43334,14 @@
       }
     },
     "electron-publish": {
-      "version": "22.14.5",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.14.5.tgz",
-      "integrity": "sha512-h+NANRdaA0PqGF15GKvorseWPzh1PXa/zx4I37//PIokW8eKIov8ky23foUSb55ZFWUHGpxQJux7y2NCfBtQeg==",
+      "version": "23.0.2",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.2.tgz",
+      "integrity": "sha512-8gMYgWqv96lc83FCm85wd+tEyxNTJQK7WKyPkNkO8GxModZqt1GO8S+/vAnFGxilS/7vsrVRXFfqiCDUCSuxEg==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "22.14.5",
-        "builder-util-runtime": "8.9.1",
+        "builder-util": "23.0.2",
+        "builder-util-runtime": "9.0.0",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
@@ -43350,9 +43359,9 @@
           }
         },
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -46063,9 +46072,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -47152,9 +47161,9 @@
       "dev": true
     },
     "isbinaryfile": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.8.tgz",
-      "integrity": "sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
       "dev": true
     },
     "isexe": {
@@ -47249,71 +47258,25 @@
       }
     },
     "jake": {
-      "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-      "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+      "version": "10.8.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.4.tgz",
+      "integrity": "sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==",
       "dev": true,
       "requires": {
         "async": "0.9.x",
-        "chalk": "^2.4.2",
+        "chalk": "^4.0.2",
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
         "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         }
       }
@@ -57912,9 +57875,9 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "cross-env": "^7.0.3",
     "dayjs": "^1.10.7",
     "electron": "^15.0.0",
-    "electron-builder": "^22.13.1",
+    "electron-builder": "^23.0.3",
     "electron-devtools-installer": "^3.2.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-header": "^3.1.1",


### PR DESCRIPTION
After upgrading my mac to 12.3, I faced the following error when trying to build the macOS app.

Someone else had this problem and they solved it by upgrading `electron-builder`. I checked the release notes and I didn't find any breaking changes. I upgraded and I could build again.

```console
$ npm run electron-pack-macos

> alephium-wallet@1.2.0-rc.0 electron-pack-macos
> npm run build && npx electron-builder --mac --universal


> alephium-wallet@1.2.0-rc.0 build
> cross-env REACT_APP_VERSION=$npm_package_version INLINE_RUNTIME_CHUNK=false REACT_APP_CSP="script-src 'self'" react-scripts build

Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  853.76 KB  build/static/js/2.90384c07.chunk.js
  196.78 KB  build/static/js/main.f3806843.chunk.js
  2.57 KB    build/static/css/2.7983be9c.chunk.css
  781 B      build/static/js/runtime-main.d77c4cef.js
  452 B      build/static/css/main.c4cfd0cb.chunk.css

The project was built assuming it is hosted at ./.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.

Find out more about deployment here:

  https://cra.link/deployment

  • electron-builder  version=22.14.5 os=21.4.0
  • loaded configuration  file=package.json ("build" field)
  • loaded parent configuration  preset=react-cra
  • writing effective config  file=dist/builder-effective-config.yaml
  • packaging       platform=darwin arch=x64 electron=15.3.2 appOutDir=dist/mac-universal--x64
  • packaging       platform=darwin arch=arm64 electron=15.3.2 appOutDir=dist/mac-universal--arm64
  • packaging       platform=darwin arch=universal electron=15.3.2 appOutDir=dist/mac-universal
  • skipped macOS application code signing  reason=cannot find valid "Developer ID Application" identity or custom non-Apple code signing certificate, see https://electron.build/code-signing allIdentities=     0 identities found
                                                Valid identities only
     0 valid identities found
  • building        target=macOS zip arch=universal file=dist/Alephium-1.2.0-rc.0-universal-mac.zip
  • building        target=DMG arch=universal file=dist/Alephium-1.2.0-rc.0-universal.dmg
  • building block map  blockMapFile=dist/Alephium-1.2.0-rc.0-universal-mac.zip.blockmap
  ⨯ Exit code: ENOENT. spawn /usr/bin/python ENOENT  failedTask=build stackTrace=Error: Exit code: ENOENT. spawn /usr/bin/python ENOENT
    at /Users/ilias/dev/alephium/alephium-wallet/node_modules/builder-util/src/util.ts:133:18
    at exithandler (child_process.js:390:5)
    at ChildProcess.errorhandler (child_process.js:402:5)
    at ChildProcess.emit (events.js:400:28)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:280:12)
    at onErrorNT (internal/child_process.js:469:16)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
```