### PR TITLE
Update release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ npm run electron-pack-linux:arm64
 
 To release a new version:
 
-1. Create a commit that updates the package version in package.json and package-lock.json and a tag with:
+1. Checkout the master branch:
+   ```shell
+   git checkout master
+   ```
+2. Create a commit that updates the package version in package.json and package-lock.json and a tag with:
    ```shell
    npm version patch # if you want to bump the patch version
    npm version minor # if you want to bump the minor version
@@ -57,18 +61,12 @@ To release a new version:
    npm version preminor --preid=rc # if you want to create a release candidate and bump the minor version
    npm version premajor --preid=rc # if you want to create a release candidate and bump the major version
    ```
-2. Push the tag to GitHub and trigger the release workflow that will build the downloadable binaries:
+3. Push the new commit and new tag to GitHub to trigger the release workflow that will build the downloadable binaries:
 
    ```shell
+   git push
    git push [remote] <tag>
    ```
-
-3. Unless you are on `master`, create a new branch and push it to GitHub so that the tagged commit belongs to a branch of this repo with:
-   ```shell
-   git checkout -b <tag>
-   git push
-   ```
-   Otherwise, just push to `master`.
 
 ## Credits
 


### PR DESCRIPTION
During the release of v1.2.0 today we faced an issue. The issue was that the release workflow was triggered after I performed step 2, but the commit that updated the version of the project from 1.2.0-rc.0 to 1.2.0 was not pushed (that was step 3 of our process). After performing step 3, the new release workflow worked correctly.

This commit updates the docs to avoid this issue in the future.