### PR TITLE
Fix param to cliqueClient.transactionSend

### DIFF
--- a/src/utils/api-clients.ts
+++ b/src/utils/api-clients.ts
@@ -102,22 +102,22 @@ export async function createClient(settings: Settings['network']) {
     }
 
     const signAndSendTransaction = async (
-      address: Address,
+      fromAddress: Address,
       txId: string,
       unsignedTx: string,
-      toHash: AddressHash,
+      toAddressHash: AddressHash,
       type: TransactionType,
       network: NetworkType,
       amount?: bigint
     ) => {
-      const signature = cliqueClient.transactionSign(txId, address.privateKey)
-      const response = await cliqueClient.transactionSend(toHash, unsignedTx, signature)
+      const signature = cliqueClient.transactionSign(txId, fromAddress.privateKey)
+      const response = await cliqueClient.transactionSend(fromAddress.hash, unsignedTx, signature)
 
       if (response.data) {
-        address.addPendingTransaction({
+        fromAddress.addPendingTransaction({
           txId: response.data.txId,
-          fromAddress: address.hash,
-          toAddress: toHash,
+          fromAddress: fromAddress.hash,
+          toAddress: toAddressHash,
           timestamp: new Date().getTime(),
           amount,
           type,


### PR DESCRIPTION
Looking at the SDK, I noticed that we are passing the wrong parameter to the [`transactionSend` function](https://github.com/alephium/js-sdk/blob/master/lib/clique.ts#L115).

This didn't matter because so far we did not use the a multi node clique (`isMultiNodesClique` was set to `false` in the desktop wallet), so the result of `getClientIndex` was always `0`, no matter the address we passed to it.