### PR TITLE
Modal tweaks and various layout improvement

### DIFF
--- a/src/components/AddressMetadataForm.tsx
+++ b/src/components/AddressMetadataForm.tsx
@@ -41,7 +41,7 @@ const AddressMetadataForm = ({
   isMainAddressToggleEnabled
 }: AddressMetadataFormProps) => (
   <>
-    <ColoredLabelInput placeholder="Address label" onChange={setLabel} value={label} id="label" maxLength={50} />
+    <ColoredLabelInput label="Address label" onChange={setLabel} value={label} id="label" maxLength={50} />
     {singleAddress && (
       <>
         <HorizontalDivider narrow />

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -31,6 +31,7 @@ interface ButtonProps extends HTMLMotionProps<'button'> {
   squared?: boolean
   submit?: boolean
   short?: boolean
+  wide?: boolean
 }
 
 const Button = ({ children, disabled, submit, ...props }: ButtonProps) => {
@@ -72,8 +73,8 @@ const StyledButton = styled(motion.button)<ButtonProps>`
   align-items: center;
   justify-content: center;
   height: ${({ squared, short }) => (squared ? '40px' : short ? '34px' : 'var(--inputHeight)')};
-  width: ${({ squared, short }) => (squared ? '40px' : short ? 'auto' : '80%')};
-  max-width: 250px;
+  width: ${({ squared, short, wide }) => (squared ? '40px' : short ? 'auto' : wide ? '100%' : '80%')};
+  max-width: ${({ wide }) => (wide ? 'auto' : '250px')};
   border-radius: var(--radius-small);
   border: none;
   background-color: ${({ theme, secondary, transparent, alert }) =>

--- a/src/components/InfoBox.tsx
+++ b/src/components/InfoBox.tsx
@@ -48,7 +48,6 @@ const InfoBox: FC<InfoBoxProps> = ({
   ellipsis,
   wordBreak,
   onClick,
-  small,
   short,
   children,
   contrast,
@@ -68,7 +67,12 @@ const InfoBox: FC<InfoBoxProps> = ({
       >
         {Icon && (
           <IconContainer>
-            <Icon color={importance ? theme.global.accent : theme.font.primary} strokeWidth={1.5} />
+            <Icon
+              color={
+                importance ? (importance === 'alert' ? theme.global.alert : theme.global.accent) : theme.font.primary
+              }
+              strokeWidth={1.5}
+            />
           </IconContainer>
         )}
         <TextContainer wordBreak={wordBreak} ellipsis={ellipsis}>

--- a/src/components/Inputs/AddressSelect.tsx
+++ b/src/components/Inputs/AddressSelect.tsx
@@ -37,7 +37,7 @@ interface AddressSelectProps {
   options: Address[]
   onAddressChange: (address: Address) => void
   defaultAddress?: Address
-  placeholder?: string
+  label?: string
   disabled?: boolean
   className?: string
   hideEmptyAvailableBalance?: boolean
@@ -46,7 +46,7 @@ interface AddressSelectProps {
 function AddressSelect({
   options,
   title,
-  placeholder,
+  label,
   disabled,
   defaultAddress,
   className,
@@ -80,7 +80,9 @@ function AddressSelect({
         onClick={() => !disabled && setIsAddressSelectModalOpen(true)}
         disabled={!!disabled}
       >
-        <InputLabel inputHasValue={!!address}>{placeholder}</InputLabel>
+        <InputLabel inputHasValue={!!address} htmlFor={id}>
+          {label}
+        </InputLabel>
         {!disabled && (
           <MoreIcon>
             <MoreVertical />

--- a/src/components/Inputs/AddressSelect.tsx
+++ b/src/components/Inputs/AddressSelect.tsx
@@ -28,7 +28,7 @@ import Amount from '../Amount'
 import InfoBox from '../InfoBox'
 import { sectionChildrenVariants } from '../PageComponents/PageContainers'
 import Truncate from '../Truncate'
-import { inputDefaultStyle, InputLabel, inputPlaceHolderVariants, InputProps } from '.'
+import { inputDefaultStyle, InputLabel, InputProps } from '.'
 import { MoreIcon, OptionItem, SelectContainer } from './Select'
 
 interface AddressSelectProps {
@@ -80,9 +80,7 @@ function AddressSelect({
         onClick={() => !disabled && setIsAddressSelectModalOpen(true)}
         disabled={!!disabled}
       >
-        <InputLabel variants={inputPlaceHolderVariants} animate={!address ? 'down' : 'up'} htmlFor={id}>
-          {placeholder}
-        </InputLabel>
+        <InputLabel inputHasValue={!!address}>{placeholder}</InputLabel>
         {!disabled && (
           <MoreIcon>
             <MoreVertical />

--- a/src/components/Inputs/AmountInput.tsx
+++ b/src/components/Inputs/AmountInput.tsx
@@ -71,7 +71,7 @@ const AmountInput = ({ className, availableAmount, ...props }: AmountInputProps)
         type="number"
         min={minAmountInAlph}
         max={availableAmountInAlph}
-        placeholder={
+        label={
           <>
             Amount (<AlefSymbol color={theme.font.secondary} />)
           </>

--- a/src/components/Inputs/ColoredLabelInput.tsx
+++ b/src/components/Inputs/ColoredLabelInput.tsx
@@ -51,7 +51,7 @@ let ColoredLabelInput = ({ placeholder, onChange, value, className, id, maxLengt
   return (
     <div className={className}>
       <InputStyled
-        placeholder={placeholder}
+        label={placeholder}
         autoComplete="off"
         onChange={(e) => setLabel(e.target.value)}
         value={label}

--- a/src/components/Inputs/ColoredLabelInput.tsx
+++ b/src/components/Inputs/ColoredLabelInput.tsx
@@ -34,34 +34,34 @@ interface ColoredLabelInputProps {
   className?: string
   onChange: ({ title, color }: ColoredLabelInputValue) => void
   disabled?: boolean
-  placeholder?: string
+  label?: string
   id?: string
   maxLength?: number
 }
 
-let ColoredLabelInput = ({ placeholder, onChange, value, className, id, maxLength }: ColoredLabelInputProps) => {
-  const [label, setLabel] = useState(value.title)
+let ColoredLabelInput = ({ label, onChange, value, className, id, maxLength }: ColoredLabelInputProps) => {
+  const [title, setTitle] = useState(value.title)
   const [color, setColor] = useState(value.color)
   const [isFocused, setIsFocused] = useState(false)
 
   useEffect(() => {
-    onChange({ title: label, color })
-  }, [label, color, onChange])
+    onChange({ title, color })
+  }, [title, color, onChange])
 
   return (
     <div className={className}>
       <InputStyled
-        label={placeholder}
+        label={label}
         autoComplete="off"
-        onChange={(e) => setLabel(e.target.value)}
-        value={label}
+        onChange={(e) => setTitle(e.target.value)}
+        value={title}
         id={id}
         color={color}
         maxLength={maxLength}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
       />
-      {label && <AddressBadgeStyled color={color} rounded addressName={label} seeThroughBg={isFocused} />}
+      {title && <AddressBadgeStyled color={color} rounded addressName={title} seeThroughBg={isFocused} />}
       <ColorPicker onChange={setColor} value={color} />
     </div>
   )

--- a/src/components/Inputs/InlineLabelValueInput.tsx
+++ b/src/components/Inputs/InlineLabelValueInput.tsx
@@ -29,7 +29,7 @@ interface InlineLabelValueInputProps {
 const InlineLabelValueInput = ({ label, InputComponent, description, className }: InlineLabelValueInputProps) => (
   <KeyValueInputContainer className={className}>
     <KeyContainer>
-      {label}
+      <Label>{label}</Label>
       {description && <DescriptionContainer>{description}</DescriptionContainer>}
     </KeyContainer>
     <InputContainer>{InputComponent}</InputContainer>
@@ -49,6 +49,10 @@ const KeyContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   gap: var(--spacing-1);
+`
+
+const Label = styled.label`
+  font-weight: var(--fontWeight-semiBold);
 `
 
 const DescriptionContainer = styled.div`

--- a/src/components/Inputs/Input.tsx
+++ b/src/components/Inputs/Input.tsx
@@ -26,7 +26,7 @@ import styled from 'styled-components'
 import { sectionChildrenVariants } from '../PageComponents/PageContainers'
 import { inputDefaultStyle, InputErrorMessage, InputLabel, InputProps, InputValidIconContainer } from '.'
 
-const Input = ({ placeholder, error, isValid, disabled, onChange, value, ...props }: InputProps) => {
+const Input = ({ label, error, isValid, disabled, onChange, value, ...props }: InputProps) => {
   const [canBeAnimated, setCanBeAnimated] = useState(false)
 
   const className = classNames(props.className, {
@@ -45,7 +45,9 @@ const Input = ({ placeholder, error, isValid, disabled, onChange, value, ...prop
       onAnimationComplete={() => setCanBeAnimated(true)}
       custom={disabled}
     >
-      <InputLabel inputHasValue={!!value}>{placeholder}</InputLabel>
+      <InputLabel inputHasValue={!!value} htmlFor={props.id}>
+        {label}
+      </InputLabel>
       <StyledInput
         {...props}
         value={value}

--- a/src/components/Inputs/Input.tsx
+++ b/src/components/Inputs/Input.tsx
@@ -24,14 +24,7 @@ import { useState } from 'react'
 import styled from 'styled-components'
 
 import { sectionChildrenVariants } from '../PageComponents/PageContainers'
-import {
-  inputDefaultStyle,
-  InputErrorMessage,
-  InputLabel,
-  inputPlaceHolderVariants,
-  InputProps,
-  InputValidIconContainer
-} from '.'
+import { inputDefaultStyle, InputErrorMessage, InputLabel, InputProps, InputValidIconContainer } from '.'
 
 const Input = ({ placeholder, error, isValid, disabled, onChange, value, ...props }: InputProps) => {
   const [canBeAnimated, setCanBeAnimated] = useState(false)
@@ -52,14 +45,7 @@ const Input = ({ placeholder, error, isValid, disabled, onChange, value, ...prop
       onAnimationComplete={() => setCanBeAnimated(true)}
       custom={disabled}
     >
-      <InputLabel
-        variants={inputPlaceHolderVariants}
-        animate={!value ? 'down' : 'up'}
-        transition={{ duration: 0.15 }}
-        htmlFor={props.id}
-      >
-        {placeholder}
-      </InputLabel>
+      <InputLabel inputHasValue={!!value}>{placeholder}</InputLabel>
       <StyledInput
         {...props}
         value={value}

--- a/src/components/Inputs/Input.tsx
+++ b/src/components/Inputs/Input.tsx
@@ -52,7 +52,12 @@ const Input = ({ placeholder, error, isValid, disabled, onChange, value, ...prop
       onAnimationComplete={() => setCanBeAnimated(true)}
       custom={disabled}
     >
-      <InputLabel variants={inputPlaceHolderVariants} animate={!value ? 'down' : 'up'} htmlFor={props.id}>
+      <InputLabel
+        variants={inputPlaceHolderVariants}
+        animate={!value ? 'down' : 'up'}
+        transition={{ duration: 0.15 }}
+        htmlFor={props.id}
+      >
         {placeholder}
       </InputLabel>
       <StyledInput

--- a/src/components/Inputs/Select.tsx
+++ b/src/components/Inputs/Select.tsx
@@ -32,7 +32,7 @@ interface SelectOption<T> {
 }
 
 interface SelectProps<T> {
-  placeholder?: string
+  label?: string
   disabled?: boolean
   controlledValue?: SelectOption<T>
   options: SelectOption<T>[]
@@ -46,7 +46,7 @@ interface SelectProps<T> {
 function Select<T>({
   options,
   title,
-  placeholder,
+  label,
   disabled,
   controlledValue,
   className,
@@ -91,7 +91,9 @@ function Select<T>({
         custom={disabled}
         onClick={() => setShowPopup(true)}
       >
-        <InputLabel inputHasValue={!!value}>{placeholder}</InputLabel>
+        <InputLabel inputHasValue={!!value} htmlFor={id}>
+          {label}
+        </InputLabel>
         <MoreIcon>
           <MoreVertical />
         </MoreIcon>

--- a/src/components/Inputs/Select.tsx
+++ b/src/components/Inputs/Select.tsx
@@ -24,7 +24,7 @@ import styled, { css } from 'styled-components'
 
 import { sectionChildrenVariants } from '../PageComponents/PageContainers'
 import Popup from '../Popup'
-import { inputDefaultStyle, InputLabel, inputPlaceHolderVariants, InputProps } from './'
+import { inputDefaultStyle, InputLabel, InputProps } from './'
 
 interface SelectOption<T> {
   value: T
@@ -91,9 +91,7 @@ function Select<T>({
         custom={disabled}
         onClick={() => setShowPopup(true)}
       >
-        <InputLabel variants={inputPlaceHolderVariants} animate={!value ? 'down' : 'up'} htmlFor={id}>
-          {placeholder}
-        </InputLabel>
+        <InputLabel inputHasValue={!!value}>{placeholder}</InputLabel>
         <MoreIcon>
           <MoreVertical />
         </MoreIcon>

--- a/src/components/Inputs/index.tsx
+++ b/src/components/Inputs/index.tsx
@@ -22,11 +22,11 @@ import styled, { css } from 'styled-components'
 import tinycolor from 'tinycolor2'
 
 export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'placeholder'> {
+  label?: React.ReactNode
   error?: React.ReactNode
   isValid?: boolean
   disabled?: boolean
   className?: string
-  placeholder?: React.ReactNode
 }
 
 export interface TextAreaProps extends React.InputHTMLAttributes<HTMLTextAreaElement> {
@@ -103,7 +103,6 @@ export let InputLabel: FC<HTMLMotionProps<'label'> & { inputHasValue: boolean }>
     variants={inputPlaceHolderVariants}
     animate={!inputHasValue ? 'down' : 'up'}
     transition={{ duration: 0.15 }}
-    htmlFor={props.id}
   />
 )
 

--- a/src/components/Inputs/index.tsx
+++ b/src/components/Inputs/index.tsx
@@ -16,7 +16,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { motion, Variants } from 'framer-motion'
+import { HTMLMotionProps, motion, Variants } from 'framer-motion'
+import { FC } from 'react'
 import styled, { css } from 'styled-components'
 import tinycolor from 'tinycolor2'
 
@@ -96,7 +97,17 @@ export const InputErrorMessage = styled(motion.label)<InputProps>`
   color: ${({ theme }) => theme.global.alert};
 `
 
-export const InputLabel = styled(motion.label)`
+export let InputLabel: FC<HTMLMotionProps<'label'> & { inputHasValue: boolean }> = ({ inputHasValue, ...props }) => (
+  <motion.label
+    {...props}
+    variants={inputPlaceHolderVariants}
+    animate={!inputHasValue ? 'down' : 'up'}
+    transition={{ duration: 0.15 }}
+    htmlFor={props.id}
+  />
+)
+
+InputLabel = styled(InputLabel)`
   position: absolute;
   top: 15px;
   left: 13px;

--- a/src/components/Inputs/index.tsx
+++ b/src/components/Inputs/index.tsx
@@ -103,6 +103,7 @@ export const InputLabel = styled(motion.label)`
   font-weight: var(--fontWeight-medium);
   color: ${({ theme }) => theme.font.secondary};
   pointer-events: none;
+  transform-origin: left;
 `
 
 export const InputValidIconContainer = styled(motion.div)`

--- a/src/components/Inputs/index.tsx
+++ b/src/components/Inputs/index.tsx
@@ -17,19 +17,19 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { HTMLMotionProps, motion, Variants } from 'framer-motion'
-import { FC } from 'react'
+import { FC, InputHTMLAttributes, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 import tinycolor from 'tinycolor2'
 
-export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'placeholder'> {
-  label?: React.ReactNode
-  error?: React.ReactNode
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'placeholder'> {
+  label?: ReactNode
+  error?: ReactNode
   isValid?: boolean
   disabled?: boolean
   className?: string
 }
 
-export interface TextAreaProps extends React.InputHTMLAttributes<HTMLTextAreaElement> {
+export interface TextAreaProps extends InputHTMLAttributes<HTMLTextAreaElement> {
   error?: string
   isValid?: boolean
   disabled?: boolean

--- a/src/components/Paragraph.tsx
+++ b/src/components/Paragraph.tsx
@@ -50,6 +50,7 @@ const Paragraph: FC<HTMLMotionProps<'p'> & ParagraphProps> = ({
 const StyledParagraph = styled(motion.p)<ParagraphProps>`
   white-space: pre-wrap;
   font-weight: var(--fontWeight-medium);
+  width: 100%;
 
   ${({ centered }) =>
     centered &&

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -58,11 +58,10 @@ const PasswordConfirmation = ({
   return (
     <>
       <Section>
-        <Paragraph secondary>{text || 'Please type your password'}</Paragraph>
-        <Input value={password} placeholder="Password" type="password" onChange={(e) => setPassword(e.target.value)} />
+        <Input value={password} placeholder={text} type="password" onChange={(e) => setPassword(e.target.value)} />
       </Section>
       <Section>
-        <Button onClick={validatePassword} submit>
+        <Button onClick={validatePassword} submit wide>
           {buttonText || 'Submit'}
         </Button>
       </Section>

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -57,13 +57,7 @@ const PasswordConfirmation = ({
   return (
     <>
       <Section>
-        <Input
-          value={password}
-          placeholder={text}
-          type="password"
-          onChange={(e) => setPassword(e.target.value)}
-          autoFocus
-        />
+        <Input value={password} label={text} type="password" onChange={(e) => setPassword(e.target.value)} autoFocus />
       </Section>
       <Section>
         <Button onClick={validatePassword} submit wide>

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -58,10 +58,8 @@ const PasswordConfirmation = ({
   return (
     <>
       <Section>
+        <Paragraph secondary>{text || 'Please type your password'}</Paragraph>
         <Input value={password} placeholder="Password" type="password" onChange={(e) => setPassword(e.target.value)} />
-        <Paragraph secondary centered>
-          {text || 'Type your password'}
-        </Paragraph>
       </Section>
       <Section>
         <Button onClick={validatePassword} submit>

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -23,7 +23,6 @@ import { useGlobalContext } from '../contexts/global'
 import Button from './Button'
 import Input from './Inputs/Input'
 import { Section } from './PageComponents/PageContainers'
-import Paragraph from './Paragraph'
 
 const Storage = getStorage()
 
@@ -58,7 +57,13 @@ const PasswordConfirmation = ({
   return (
     <>
       <Section>
-        <Input value={password} placeholder={text} type="password" onChange={(e) => setPassword(e.target.value)} />
+        <Input
+          value={password}
+          placeholder={text}
+          type="password"
+          onChange={(e) => setPassword(e.target.value)}
+          autoFocus
+        />
       </Section>
       <Section>
         <Button onClick={validatePassword} submit wide>

--- a/src/modals/AddressOptionsModal.tsx
+++ b/src/modals/AddressOptionsModal.tsx
@@ -127,4 +127,5 @@ const SweepButton = styled.div``
 const AvailableAmount = styled.div`
   font-size: 10px;
   color: ${({ theme }) => theme.font.secondary};
+  text-align: right;
 `

--- a/src/modals/AddressSweepModal.tsx
+++ b/src/modals/AddressSweepModal.tsx
@@ -115,7 +115,7 @@ const AddressSweepModal = ({ sweepAddress, onClose, onSuccessfulSweep }: Address
     <CenteredModal title={sweepAddress ? 'Sweep address' : 'Consolidate UTXOs'} onClose={onClose} isLoading={isLoading}>
       <Content>
         <AddressSelect
-          placeholder="From address"
+          label="From address"
           title="Select the address to sweep the funds from."
           options={addresses}
           defaultAddress={sweepAddresses.from}
@@ -125,7 +125,7 @@ const AddressSweepModal = ({ sweepAddress, onClose, onSuccessfulSweep }: Address
           hideEmptyAvailableBalance
         />
         <AddressSelect
-          placeholder="To address"
+          label="To address"
           title="Select the address to sweep the funds to."
           options={toAddressOptions}
           defaultAddress={sweepAddresses.to}

--- a/src/modals/CenteredModal.tsx
+++ b/src/modals/CenteredModal.tsx
@@ -32,6 +32,7 @@ interface CenteredModalProps extends ModalContainerProps {
   subtitle?: string
   isLoading?: boolean
   header?: ReactNode
+  narrow?: boolean
 }
 
 const CenteredModal: FC<CenteredModalProps> = ({
@@ -41,6 +42,7 @@ const CenteredModal: FC<CenteredModalProps> = ({
   focusMode,
   isLoading,
   header,
+  narrow = false,
   children
 }) => (
   <ModalContainer onClose={onClose} focusMode={focusMode} hasPadding>
@@ -49,6 +51,7 @@ const CenteredModal: FC<CenteredModalProps> = ({
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 20 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
+      narrow={narrow}
     >
       <ModalHeader contrast={!!header}>
         <TitleRow>
@@ -90,12 +93,12 @@ export const HeaderLogo = styled.div`
   width: 100%;
 `
 
-const CenteredBox = styled(motion.div)`
+const CenteredBox = styled(motion.div)<{ narrow: boolean }>`
   display: flex;
   flex-direction: column;
   margin: auto;
   width: 100%;
-  max-width: 600px;
+  max-width: ${({ narrow }) => (narrow ? '380px' : '600px')};
   max-height: 95vh;
   box-shadow: ${({ theme }) => theme.shadow.tertiary};
   border-radius: var(--radius);

--- a/src/modals/NewAddressModal.tsx
+++ b/src/modals/NewAddressModal.tsx
@@ -116,7 +116,7 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
       {singleAddress && (
         <ExpandableSection sectionTitleClosed="Advanced options">
           <Select
-            placeholder="Group"
+            label="Group"
             controlledValue={newAddressGroup !== undefined ? generateGroupSelectOption(newAddressGroup) : undefined}
             options={Array.from(Array(TOTAL_NUMBER_OF_GROUPS)).map((_, index) => generateGroupSelectOption(index))}
             onValueChange={(newValue) => {

--- a/src/modals/SecretPhraseModal.tsx
+++ b/src/modals/SecretPhraseModal.tsx
@@ -31,11 +31,11 @@ const SecretPhraseModal = ({ onClose }: { onClose: () => void }) => {
   const [isDisplayingPhrase, setIsDisplayingPhrase] = useState(false)
 
   return (
-    <CenteredModal title="Secret phrase" onClose={onClose} focusMode>
+    <CenteredModal title="Secret phrase" onClose={onClose} focusMode narrow={!isDisplayingPhrase}>
       {!isDisplayingPhrase ? (
         <div>
           <PasswordConfirmation
-            text="Type your password above to show your secret phrase."
+            text="Type your password to show your secret phrase."
             buttonText="Show"
             onCorrectPasswordEntered={() => setIsDisplayingPhrase(true)}
           />

--- a/src/modals/SendModal/TransactionForm.tsx
+++ b/src/modals/SendModal/TransactionForm.tsx
@@ -108,7 +108,7 @@ const SendModalTransactionForm = ({ data, onSubmit, onCancel }: TransactionFormP
     <>
       <ModalContent>
         <AddressSelect
-          placeholder="From address"
+          label="From address"
           title="Select the address to send funds from."
           options={addresses}
           defaultAddress={fromAddress}
@@ -117,7 +117,7 @@ const SendModalTransactionForm = ({ data, onSubmit, onCancel }: TransactionFormP
           hideEmptyAvailableBalance
         />
         <Input
-          placeholder="Recipient's address"
+          label="Recipient's address"
           value={toAddress}
           onChange={(e) => handleAddressChange(e.target.value)}
           error={addressError}
@@ -134,7 +134,7 @@ const SendModalTransactionForm = ({ data, onSubmit, onCancel }: TransactionFormP
       <ExpandableSectionStyled sectionTitleClosed="Advanced settings">
         <Input
           id="gas-amount"
-          placeholder="Gas amount"
+          label="Gas amount"
           value={gasAmount}
           onChange={(e) => handleGasAmountChange(e.target.value)}
           type="number"
@@ -143,7 +143,7 @@ const SendModalTransactionForm = ({ data, onSubmit, onCancel }: TransactionFormP
         />
         <Input
           id="gas-price"
-          placeholder={
+          label={
             <>
               Gas price (<AlefSymbol color={theme.font.secondary} />)
             </>

--- a/src/modals/SendModal/index.tsx
+++ b/src/modals/SendModal/index.tsx
@@ -221,7 +221,7 @@ const SendModal = ({ onClose }: SendModalProps) => {
   const modalHeader = theme.name === 'dark' ? <PaperPlaneDarkSVG width="315px" /> : <PaperPlaneLightSVG width="315px" />
 
   return (
-    <CenteredModal title={title} onClose={onClose} isLoading={isLoading} header={modalHeader}>
+    <CenteredModal title={title} onClose={onClose} isLoading={isLoading} header={modalHeader} narrow={step === 3}>
       {step === 1 && <SendModalTransactionForm data={transactionData} onSubmit={buildTransaction} onCancel={onClose} />}
       {step === 2 && transactionData && fees && (
         <SendModalCheckTransaction

--- a/src/modals/SendModal/index.tsx
+++ b/src/modals/SendModal/index.tsx
@@ -221,7 +221,13 @@ const SendModal = ({ onClose }: SendModalProps) => {
   const modalHeader = theme.name === 'dark' ? <PaperPlaneDarkSVG width="315px" /> : <PaperPlaneLightSVG width="315px" />
 
   return (
-    <CenteredModal title={title} onClose={onClose} isLoading={isLoading} header={modalHeader} narrow={step === 3}>
+    <CenteredModal
+      title={title}
+      onClose={onClose}
+      isLoading={isLoading}
+      header={step !== 3 && modalHeader}
+      narrow={step === 3}
+    >
       {step === 1 && <SendModalTransactionForm data={transactionData} onSubmit={buildTransaction} onCancel={onClose} />}
       {step === 2 && transactionData && fees && (
         <SendModalCheckTransaction

--- a/src/modals/SettingsModal/GeneralSettingsSection.tsx
+++ b/src/modals/SettingsModal/GeneralSettingsSection.tsx
@@ -63,7 +63,7 @@ const GeneralSettingsSection = () => {
             onChange={(v) =>
               updateSettings('general', { walletLockTimeInMinutes: v.target.value ? parseInt(v.target.value) : null })
             }
-            placeholder={walletLockTimeInMinutes ? 'Minutes' : 'Off'}
+            label={walletLockTimeInMinutes ? 'Minutes' : 'Off'}
             type="number"
             step={1}
             min={1}

--- a/src/modals/SettingsModal/GeneralSettingsSection.tsx
+++ b/src/modals/SettingsModal/GeneralSettingsSection.tsx
@@ -97,7 +97,7 @@ const GeneralSettingsSection = () => {
       )}
       <AnimatePresence>
         {isPasswordModelOpen && (
-          <CenteredModal title="Password" onClose={() => setIsPasswordModalOpen(false)} focusMode>
+          <CenteredModal title="Password" onClose={() => setIsPasswordModalOpen(false)} focusMode narrow>
             <PasswordConfirmation
               text="Type your password to change this setting."
               buttonText="Enter"

--- a/src/modals/SettingsModal/NetworkSettingsSection.tsx
+++ b/src/modals/SettingsModal/NetworkSettingsSection.tsx
@@ -109,7 +109,7 @@ const NetworkSettingsSection = () => {
         onValueChange={handleNetworkPresetChange}
         controlledValue={networkSelectOptions.find((n) => n.value === selectedNetwork)}
         title="Network"
-        placeholder="Current network"
+        label="Current network"
         id="network"
       />
       <ExpandableSection
@@ -119,17 +119,17 @@ const NetworkSettingsSection = () => {
       >
         <UrlInputs>
           <Input
-            placeholder="Node host"
+            label="Node host"
             value={tempAdvancedSettings.nodeHost}
             onChange={(e) => editAdvancedSettings({ nodeHost: e.target.value })}
           />
           <Input
-            placeholder="Explorer API host"
+            label="Explorer API host"
             value={tempAdvancedSettings.explorerApiHost}
             onChange={(e) => editAdvancedSettings({ explorerApiHost: e.target.value })}
           />
           <Input
-            placeholder="Explorer URL"
+            label="Explorer URL"
             value={tempAdvancedSettings.explorerUrl}
             onChange={(e) => editAdvancedSettings({ explorerUrl: e.target.value })}
           />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -112,14 +112,14 @@ const Login = ({ accountNames, onLinkClick }: LoginProps) => {
     <>
       <SectionStyled inList>
         <Select
-          placeholder="Wallet"
+          label="Wallet"
           options={accountNames.map((u) => ({ label: u, value: u }))}
           onValueChange={(value) => handleCredentialsChange('accountName', value?.value || '')}
           title="Select a wallet"
           id="wallet"
         />
         <Input
-          placeholder="Password"
+          label="Password"
           type="password"
           autoComplete="off"
           onChange={(e) => handleCredentialsChange('password', e.target.value)}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -132,7 +132,9 @@ const Login = ({ accountNames, onLinkClick }: LoginProps) => {
           Login
         </Button>
       </SectionStyled>
-      <SwitchLink onClick={onLinkClick}>Create / import a new wallet</SwitchLink>
+      <SwitchLink onClick={onLinkClick} centered>
+        Create / import a new wallet
+      </SwitchLink>
     </>
   )
 }
@@ -154,7 +156,11 @@ const InitialActions = ({
       <Section inList>
         <Button onClick={() => history.push('/create')}>New wallet</Button>
         <Button onClick={() => history.push('/import')}>Import wallet</Button>
-        {showLinkToExistingAccounts && <SwitchLink onClick={onLinkClick}>Use an existing wallet</SwitchLink>}
+        {showLinkToExistingAccounts && (
+          <SwitchLink onClick={onLinkClick} centered>
+            Use an existing wallet
+          </SwitchLink>
+        )}
       </Section>
     </>
   )

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -115,7 +115,7 @@ const WalletLayout: FC = ({ children }) => {
           <InfoBox text={currentAccountName} label="WALLET" />
         ) : (
           <Select
-            placeholder="WALLET"
+            label="WALLET"
             options={accountNameSelectOptions}
             controlledValue={{
               label: currentAccountName,

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -138,7 +138,7 @@ const WalletLayout: FC = ({ children }) => {
       <AnimatePresence exitBeforeEnter initial={true}>
         {isSendModalOpen && <SendModal onClose={() => setIsSendModalOpen(false)} />}
         {isPasswordModalOpen && (
-          <CenteredModal title="Enter password" onClose={() => setIsPasswordModalOpen(false)}>
+          <CenteredModal narrow title="Enter password" onClose={() => setIsPasswordModalOpen(false)}>
             <PasswordConfirmation
               text={`Enter password for "${switchToAccountName}"`}
               buttonText="Login"

--- a/src/pages/WalletManagement/CheckWordsPage.tsx
+++ b/src/pages/WalletManagement/CheckWordsPage.tsx
@@ -206,7 +206,7 @@ const CheckWordsPage = () => {
       </PanelTitle>
       <PanelContentContainer>
         <Section>
-          <Paragraph style={{ width: '100%' }}>Select the words in the right order.</Paragraph>
+          <Paragraph>Select the words in the right order.</Paragraph>
           <SelectedWordList
             className={selectedWords.length === wordList.current.length ? (areWordsValid ? 'valid' : 'error') : ''}
           >

--- a/src/pages/WalletManagement/CreateAccountPage.tsx
+++ b/src/pages/WalletManagement/CreateAccountPage.tsx
@@ -107,14 +107,14 @@ const CreateAccountPage = ({ isRestoring = false }: { isRestoring?: boolean }) =
         <Section inList>
           <Input
             value={accountName}
-            placeholder={isRestoring ? 'New wallet name' : 'Wallet name'}
+            label={isRestoring ? 'New wallet name' : 'Wallet name'}
             onChange={onUpdateAccountName}
             error={accountNameError}
             isValid={accountName.length > 0 && accountNameError.length === 0}
           />
           <Input
             value={password}
-            placeholder={isRestoring ? 'New password' : 'Password'}
+            label={isRestoring ? 'New password' : 'Password'}
             type="password"
             onChange={onUpdatePassword}
             error={passwordError}
@@ -122,7 +122,7 @@ const CreateAccountPage = ({ isRestoring = false }: { isRestoring?: boolean }) =
           />
           <Input
             value={passwordCheck}
-            placeholder="Retype password"
+            label="Retype password"
             type="password"
             onChange={(e) => setPasswordCheck(e.target.value)}
             error={passwordCheck && password !== passwordCheck ? 'Passwords are different' : ''}


### PR DESCRIPTION
Iterative design :
- Simplifying the `PasswordConfirmation` prompt
- New option to display a narrow modal (when focus is on one field, like password check)
- Default props for `InputLabel`