### PR TITLE
BIP39 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alephium-wallet",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
     "node_modules/@alephium/sdk/node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@alephium/sdk/node_modules/fs-extra": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -153,7 +153,7 @@
     "node_modules/@alephium/sdk/node_modules/locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -178,7 +178,7 @@
     "node_modules/@alephium/sdk/node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -190,7 +190,7 @@
     "node_modules/@alephium/sdk/node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -199,7 +199,7 @@
     "node_modules/@alephium/sdk/node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -8281,7 +8281,7 @@
     "node_modules/bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
       "dev": true,
       "dependencies": {
         "base-x": "^3.0.2"
@@ -33630,16 +33630,16 @@
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
         },
         "fs-extra": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -33660,7 +33660,7 @@
         "locate-path": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -33679,7 +33679,7 @@
         "p-locate": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -33688,13 +33688,13 @@
         "p-try": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
           "dev": true
         },
         "universalify": {
@@ -40087,7 +40087,7 @@
     "bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
       "dev": true,
       "requires": {
         "base-x": "^3.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "electron-is-dev": "^2.0.0"
       },
       "devDependencies": {
-        "@alephium/sdk": "0.0.11",
+        "@alephium/sdk": "0.0.12",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",
         "@types/jest": "^27.0.2",
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@alephium/sdk": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.0.11.tgz",
-      "integrity": "sha512-6+ErZuDU8xF0xS3WtJiEbTwdiByOdXjZjFhn0j8vZP3TSVhP7G/Dr5osDGubL033IO0YogSWi4cUVc29ryQwaw==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.0.12.tgz",
+      "integrity": "sha512-NhVxKlvF8QEF2NDl+OCMaNKm2FvMvgWxteKMB9wVVtNqweCaFqSO0wxrMD5+iE8u/aRpe96kaFGgaEJt9wTMsw==",
       "dev": true,
       "dependencies": {
         "base-x": "^4.0.0",
@@ -33605,9 +33605,9 @@
   },
   "dependencies": {
     "@alephium/sdk": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.0.11.tgz",
-      "integrity": "sha512-6+ErZuDU8xF0xS3WtJiEbTwdiByOdXjZjFhn0j8vZP3TSVhP7G/Dr5osDGubL033IO0YogSWi4cUVc29ryQwaw==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.0.12.tgz",
+      "integrity": "sha512-NhVxKlvF8QEF2NDl+OCMaNKm2FvMvgWxteKMB9wVVtNqweCaFqSO0wxrMD5+iE8u/aRpe96kaFGgaEJt9wTMsw==",
       "dev": true,
       "requires": {
         "base-x": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alephium-wallet",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alephium-wallet",
-      "version": "1.2.1",
+      "version": "1.2.0",
       "dependencies": {
         "electron-context-menu": "^3.1.2",
         "electron-is-dev": "^2.0.0"
@@ -8769,14 +8769,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001283",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
-      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
+      "version": "1.0.30001363",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
+      "integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -40479,9 +40485,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001283",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
-      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
+      "version": "1.0.30001363",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
+      "integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
       "dev": true
     },
     "capture-exit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "electron-is-dev": "^2.0.0"
       },
       "devDependencies": {
-        "@alephium/sdk": "0.0.5",
+        "@alephium/sdk": "0.0.11",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",
         "@types/jest": "^27.0.2",
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@alephium/sdk": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.0.5.tgz",
-      "integrity": "sha512-jm99+EB8zWMu5WktNt6/8mVuR2Fo/21BqOw87t4mF4HCJcqDEhbWBm+KeU27XaijDmGLu+kMbGHFeyJ/nuAZDg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.0.11.tgz",
+      "integrity": "sha512-6+ErZuDU8xF0xS3WtJiEbTwdiByOdXjZjFhn0j8vZP3TSVhP7G/Dr5osDGubL033IO0YogSWi4cUVc29ryQwaw==",
       "dev": true,
       "dependencies": {
         "base-x": "^4.0.0",
@@ -33599,9 +33599,9 @@
   },
   "dependencies": {
     "@alephium/sdk": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.0.5.tgz",
-      "integrity": "sha512-jm99+EB8zWMu5WktNt6/8mVuR2Fo/21BqOw87t4mF4HCJcqDEhbWBm+KeU27XaijDmGLu+kMbGHFeyJ/nuAZDg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.0.11.tgz",
+      "integrity": "sha512-6+ErZuDU8xF0xS3WtJiEbTwdiByOdXjZjFhn0j8vZP3TSVhP7G/Dr5osDGubL033IO0YogSWi4cUVc29ryQwaw==",
       "dev": true,
       "requires": {
         "base-x": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "alephium-wallet",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "electron-context-menu": "^3.1.2",
         "electron-is-dev": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alephium-wallet",
   "description": "The official Alephium wallet",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "./",
   "author": "Alephium dev <dev@alephium.org>",
   "main": "public/electron.js",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "electron-is-dev": "^2.0.0"
   },
   "devDependencies": {
-    "@alephium/sdk": "0.0.11",
+    "@alephium/sdk": "0.0.12",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.0",
     "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alephium-wallet",
   "description": "The official Alephium wallet",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "homepage": "./",
   "author": "Alephium dev <dev@alephium.org>",
   "main": "public/electron.js",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "electron-is-dev": "^2.0.0"
   },
   "devDependencies": {
-    "@alephium/sdk": "0.0.5",
+    "@alephium/sdk": "0.0.11",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.0",
     "@types/jest": "^27.0.2",

--- a/src/components/AddressSummaryCard.tsx
+++ b/src/components/AddressSummaryCard.tsx
@@ -40,7 +40,7 @@ export const addressSummaryCardWidthPx = 100
 
 const AddressSummaryCard = ({ address, clickable, className, index, totalCards }: AddressSummaryCardProps) => {
   const navigate = useNavigate()
-  const { passphraseHash } = useGlobalContext()
+  const { isPassphraseUsed } = useGlobalContext()
 
   const collapsedPosition = !clickable ? (totalCards - index) * -109 + 5 : 0
 
@@ -55,7 +55,7 @@ const AddressSummaryCard = ({ address, clickable, className, index, totalCards }
         <AddressNameSection collapsed={!clickable}>
           <AddressBadgeStyled
             color={address.settings.color}
-            addressName={address.getLabelName(!passphraseHash)}
+            addressName={address.getLabelName(!isPassphraseUsed)}
             truncate
           />
         </AddressNameSection>

--- a/src/components/AddressSummaryCard.tsx
+++ b/src/components/AddressSummaryCard.tsx
@@ -21,6 +21,7 @@ import { useNavigate } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 
 import { Address } from '../contexts/addresses'
+import { useGlobalContext } from '../contexts/global'
 import AddressBadge from './AddressBadge'
 import Amount from './Amount'
 import ClipboardButton from './Buttons/ClipboardButton'
@@ -39,6 +40,7 @@ export const addressSummaryCardWidthPx = 100
 
 const AddressSummaryCard = ({ address, clickable, className, index, totalCards }: AddressSummaryCardProps) => {
   const navigate = useNavigate()
+  const { passphraseHash } = useGlobalContext()
 
   const collapsedPosition = !clickable ? (totalCards - index) * -109 + 5 : 0
 
@@ -51,7 +53,11 @@ const AddressSummaryCard = ({ address, clickable, className, index, totalCards }
     >
       <ClickableArea onClick={() => clickable && navigate(`/wallet/addresses/${address.hash}`)} clickable={clickable}>
         <AddressNameSection collapsed={!clickable}>
-          <AddressBadgeStyled color={address.settings.color} addressName={address.getLabelName()} truncate />
+          <AddressBadgeStyled
+            color={address.settings.color}
+            addressName={address.getLabelName(!passphraseHash)}
+            truncate
+          />
         </AddressNameSection>
         <AmountsSection collapsed={!clickable}>
           <AmountHighlighted value={BigInt(address.details.balance)} fadeDecimals />

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -39,7 +39,7 @@ const AppHeader: FC = ({ children }) => {
   const { scrollY } = useViewportScroll()
   const theme = useTheme()
   const { mainAddress } = useAddressesContext()
-  const { networkStatus, passphraseHash } = useGlobalContext()
+  const { networkStatus, isPassphraseUsed } = useGlobalContext()
   const isOffline = networkStatus === 'offline'
 
   const headerBGColor = useTransform(
@@ -84,7 +84,7 @@ const AppHeader: FC = ({ children }) => {
           IconOff={Eye}
           data-tip="Discreet mode"
         />
-        {mainAddress && !passphraseHash && (
+        {mainAddress && !isPassphraseUsed && (
           <>
             <HeaderDivider />
             <AddressBadge

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -39,7 +39,7 @@ const AppHeader: FC = ({ children }) => {
   const { scrollY } = useViewportScroll()
   const theme = useTheme()
   const { mainAddress } = useAddressesContext()
-  const { networkStatus } = useGlobalContext()
+  const { networkStatus, passphraseHash } = useGlobalContext()
   const isOffline = networkStatus === 'offline'
 
   const headerBGColor = useTransform(
@@ -84,7 +84,7 @@ const AppHeader: FC = ({ children }) => {
           IconOff={Eye}
           data-tip="Discreet mode"
         />
-        {mainAddress && (
+        {mainAddress && !passphraseHash && (
           <>
             <HeaderDivider />
             <AddressBadge

--- a/src/components/InfoBox.tsx
+++ b/src/components/InfoBox.tsx
@@ -37,7 +37,6 @@ interface InfoBoxProps {
   short?: boolean
   contrast?: boolean
   noBorders?: boolean
-  noMarginBottom?: boolean
 }
 
 const InfoBox: FC<InfoBoxProps> = ({
@@ -148,11 +147,6 @@ const Label = styled(motion.label)`
 export default styled(InfoBox)`
   width: 100%;
   margin: 0 auto var(--spacing-4) auto;
-  ${({ noMarginBottom }) =>
-    noMarginBottom &&
-    css`
-      margin-bottom: 0;
-    `};
   margin-top: var(--spacing-2);
   max-width: ${({ small }) => (small ? '300px' : 'initial')};
   line-height: 1.5em;

--- a/src/components/InfoBox.tsx
+++ b/src/components/InfoBox.tsx
@@ -90,8 +90,8 @@ const IconContainer = styled.div`
   max-width: 100px;
 
   svg {
-    height: 30%;
-    width: 30%;
+    height: 35%;
+    width: 35%;
     margin: auto;
   }
 `
@@ -155,4 +155,5 @@ export default styled(InfoBox)`
     `};
   margin-top: var(--spacing-2);
   max-width: ${({ small }) => (small ? '300px' : 'initial')};
+  line-height: 1.5em;
 `

--- a/src/components/InfoBox.tsx
+++ b/src/components/InfoBox.tsx
@@ -37,6 +37,7 @@ interface InfoBoxProps {
   short?: boolean
   contrast?: boolean
   noBorders?: boolean
+  noMarginBottom?: boolean
 }
 
 const InfoBox: FC<InfoBoxProps> = ({
@@ -147,6 +148,11 @@ const Label = styled(motion.label)`
 export default styled(InfoBox)`
   width: 100%;
   margin: 0 auto var(--spacing-4) auto;
+  ${({ noMarginBottom }) =>
+    noMarginBottom &&
+    css`
+      margin-bottom: 0;
+    `};
   margin-top: var(--spacing-2);
   max-width: ${({ small }) => (small ? '300px' : 'initial')};
 `

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -16,14 +16,12 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { ChangeEvent } from 'react'
-
 import ExpandableSection from '../ExpandableSection'
 import Input from './Input'
 
 interface Props {
   value: string
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+  onChange: (passphrase: string) => void
 }
 
 const WalletPassphrase = ({ value, onChange }: Props) => (
@@ -34,7 +32,7 @@ const WalletPassphrase = ({ value, onChange }: Props) => (
       <span> Do not panic, this is normal! Calmly try again.</span>
     </p>
     <p>Addresses need to be re-discovered to see all funds after unlocking.</p>
-    <Input value={value} label="Optional passphrase" type="password" onChange={onChange} />
+    <Input value={value} label="Optional passphrase" type="password" onChange={(e) => onChange(e.target.value)} />
   </ExpandableSection>
 )
 

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -42,10 +42,12 @@ const WalletPassphrase = ({ value, label, onChange, isValid }: Props) => {
       {!show && <ActionLinkStyled onClick={() => setShow(true)}>{label}</ActionLinkStyled>}
       {show && (
         <InfoBox Icon={AlertTriangle} importance="accent" label="Advanced option">
+          <p>The software will derive or &quot;find&quot; a wallet based on the passphrase entered below.</p>
           <p>
-            The software will derive a new wallet based on this passphrase. Addresses will need to be re-discovered to
-            see funds after unlocking.
+            <strong>An incorrect passphrase could generate a wallet with zero funds.</strong>
+            <span> Do not panic, this is normal! Calmly try again.</span>
           </p>
+          <p>Addresses need to be re-discovered to see all funds after unlocking.</p>
           <SectionStyled>
             <Input
               value={value}

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { X } from 'lucide-react'
+import { ChangeEvent, useState } from 'react'
+import styled, { useTheme } from 'styled-components'
+
+import { Section } from '../../components/PageComponents/PageContainers'
+import ActionLink from '../ActionLink'
+import Button from '../Button'
+import Input from './Input'
+
+interface Props {
+  value: string
+  label: string
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+  isValid: boolean
+}
+
+const WalletPassphrase = ({ value, label, onChange, isValid }: Props) => {
+  const theme = useTheme()
+  const [show, setShow] = useState(false)
+
+  return (
+    <>
+      {!show && <ActionLinkStyled onClick={() => setShow(true)}>{label}</ActionLinkStyled>}
+      {show && (
+        <SectionStyled>
+          <Input
+            value={value}
+            label="Optional passphrase"
+            type="password"
+            onChange={onChange}
+            isValid={isValid}
+            disabled={false}
+          />
+          <CloseButton onClick={() => setShow(false)} secondary>
+            <X color={theme.font.primary} size={18} />
+          </CloseButton>
+        </SectionStyled>
+      )}
+    </>
+  )
+}
+
+export default WalletPassphrase
+
+const ActionLinkStyled = styled(ActionLink)`
+  margin-top: 1rem;
+`
+
+const SectionStyled = styled(Section)`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  flex-direction: row;
+`
+
+const CloseButton = styled(Button)`
+  width: fit-content;
+  margin-left: 1rem;
+`

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -16,71 +16,26 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AlertTriangle, X } from 'lucide-react'
-import { ChangeEvent, useState } from 'react'
-import styled, { useTheme } from 'styled-components'
+import { ChangeEvent } from 'react'
 
-import InfoBox from '../../components/InfoBox'
-import { Section } from '../../components/PageComponents/PageContainers'
-import ActionLink from '../ActionLink'
-import Button from '../Button'
+import ExpandableSection from '../ExpandableSection'
 import Input from './Input'
 
 interface Props {
   value: string
-  label: string
   onChange: (e: ChangeEvent<HTMLInputElement>) => void
-  isValid: boolean
 }
 
-const WalletPassphrase = ({ value, label, onChange, isValid }: Props) => {
-  const theme = useTheme()
-  const [show, setShow] = useState(false)
-
-  return (
-    <>
-      {!show && <ActionLinkStyled onClick={() => setShow(true)}>{label}</ActionLinkStyled>}
-      {show && (
-        <InfoBox Icon={AlertTriangle} importance="accent" label="Advanced option">
-          <p>The software will derive or &quot;find&quot; a wallet based on the passphrase entered below.</p>
-          <p>
-            <strong>An incorrect passphrase could generate a wallet with zero funds.</strong>
-            <span> Do not panic, this is normal! Calmly try again.</span>
-          </p>
-          <p>Addresses need to be re-discovered to see all funds after unlocking.</p>
-          <SectionStyled>
-            <Input
-              value={value}
-              label="Optional passphrase"
-              type="password"
-              onChange={onChange}
-              isValid={isValid}
-              disabled={false}
-            />
-            <CloseButton onClick={() => setShow(false)} secondary>
-              <X color={theme.font.primary} size={18} />
-            </CloseButton>
-          </SectionStyled>
-        </InfoBox>
-      )}
-    </>
-  )
-}
+const WalletPassphrase = ({ value, onChange }: Props) => (
+  <ExpandableSection sectionTitleClosed="Optional passphrase" centered>
+    <p>The software will derive or &quot;find&quot; a wallet based on the passphrase entered below.</p>
+    <p>
+      <strong>An incorrect passphrase could generate a wallet with zero funds.</strong>
+      <span> Do not panic, this is normal! Calmly try again.</span>
+    </p>
+    <p>Addresses need to be re-discovered to see all funds after unlocking.</p>
+    <Input value={value} label="Optional passphrase" type="password" onChange={onChange} />
+  </ExpandableSection>
+)
 
 export default WalletPassphrase
-
-const ActionLinkStyled = styled(ActionLink)`
-  margin-top: 1rem;
-`
-
-const SectionStyled = styled(Section)`
-  display: flex;
-  width: 100%;
-  align-items: center;
-  flex-direction: row;
-`
-
-const CloseButton = styled(Button)`
-  width: fit-content;
-  margin-left: 1rem;
-`

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -69,6 +69,7 @@ const SectionStyled = styled(Section)`
   width: 100%;
   align-items: center;
   flex-direction: row;
+  margin-top: 1rem;
 `
 
 const CloseButton = styled(Button)`

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -16,10 +16,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { X } from 'lucide-react'
+import { AlertTriangle, X } from 'lucide-react'
 import { ChangeEvent, useState } from 'react'
 import styled, { useTheme } from 'styled-components'
 
+import InfoBox from '../../components/InfoBox'
 import { Section } from '../../components/PageComponents/PageContainers'
 import ActionLink from '../ActionLink'
 import Button from '../Button'
@@ -40,19 +41,25 @@ const WalletPassphrase = ({ value, label, onChange, isValid }: Props) => {
     <>
       {!show && <ActionLinkStyled onClick={() => setShow(true)}>{label}</ActionLinkStyled>}
       {show && (
-        <SectionStyled>
-          <Input
-            value={value}
-            label="Optional passphrase"
-            type="password"
-            onChange={onChange}
-            isValid={isValid}
-            disabled={false}
-          />
-          <CloseButton onClick={() => setShow(false)} secondary>
-            <X color={theme.font.primary} size={18} />
-          </CloseButton>
-        </SectionStyled>
+        <InfoBox Icon={AlertTriangle} importance="accent" label="Advanced option">
+          <p>
+            The software will derive a new wallet based on this passphrase. Addresses will need to be re-discovered to
+            see funds after unlocking.
+          </p>
+          <SectionStyled>
+            <Input
+              value={value}
+              label="Optional passphrase"
+              type="password"
+              onChange={onChange}
+              isValid={isValid}
+              disabled={false}
+            />
+            <CloseButton onClick={() => setShow(false)} secondary>
+              <X color={theme.font.primary} size={18} />
+            </CloseButton>
+          </SectionStyled>
+        </InfoBox>
       )}
     </>
   )
@@ -69,7 +76,6 @@ const SectionStyled = styled(Section)`
   width: 100%;
   align-items: center;
   flex-direction: row;
-  margin-top: 1rem;
 `
 
 const CloseButton = styled(Button)`

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -16,6 +16,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { openInWebBrowser } from '../../utils/misc'
+import ActionLink from '../ActionLink'
 import ExpandableSection from '../ExpandableSection'
 import InfoBox from '../InfoBox'
 import Input from './Input'
@@ -25,13 +27,19 @@ interface Props {
   onChange: (passphrase: string) => void
 }
 
+const passphraseLink = 'https://wiki.alephium.org/wallet/Desktop-Wallet-Guide#passphrase'
+
 const WalletPassphrase = ({ value, onChange }: Props) => (
   <ExpandableSection sectionTitleClosed="Optional passphrase" centered>
     <InfoBox noMarginBottom>
       <p>The software will derive or &quot;find&quot; a wallet based on the passphrase entered below.</p>
       <p>
         <strong>This is an advanced feature!</strong>
-        <span> Before using it, please take some time to learn more about it in our wiki.</span>
+        <span>
+          {' '}
+          Before using it, please take some time to{' '}
+          <ActionLink onClick={() => openInWebBrowser(passphraseLink)}>learn more about it</ActionLink> in our wiki.
+        </span>
       </p>
       <p>Addresses need to be re-discovered to see all funds after unlocking.</p>
       <Input value={value} label="Optional passphrase" type="password" onChange={(e) => onChange(e.target.value)} />

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AlertTriangle } from 'lucide-react'
 import styled from 'styled-components'
 
 import { openInWebBrowser } from '../../utils/misc'
@@ -34,16 +33,13 @@ const passphraseLink = 'https://wiki.alephium.org/wallet/Desktop-Wallet-Guide#pa
 
 const WalletPassphrase = ({ value, onChange }: Props) => (
   <ExpandableSection sectionTitleClosed="Optional passphrase (advanced)" centered>
-    <InfoBox noMarginBottom importance="alert" Icon={AlertTriangle}>
-      <WarningEmphasis>This is an advanced feature!</WarningEmphasis>
-      <br />
-      <span>
-        {' '}
-        Before using it, please take some time to{' '}
-        <ActionLink onClick={() => openInWebBrowser(passphraseLink)}>learn more about it</ActionLink> in our wiki.
-      </span>
-      <br />
-      <span>Addresses need to be re-discovered to see all funds after unlocking.</span>
+    <InfoBox noMarginBottom importance="alert">
+      <p>
+        <WarningEmphasis>This is an advanced feature! </WarningEmphasis>
+        <span>Use it only if you know what you are doing. Please, consult our </span>
+        <ActionLink onClick={() => openInWebBrowser(passphraseLink)}>documentation</ActionLink>
+        <span> to learn about it.</span>
+      </p>
     </InfoBox>
     <Input value={value} label="Optional passphrase" type="password" onChange={(e) => onChange(e.target.value)} />
   </ExpandableSection>

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -36,6 +36,7 @@ const WalletPassphrase = ({ value, onChange }: Props) => (
     <InfoBox noMarginBottom importance="alert">
       <p>
         <WarningEmphasis>This is an advanced feature! </WarningEmphasis>
+        <br />
         <span>Use it only if you know what you are doing. Please, consult our </span>
         <ActionLink onClick={() => openInWebBrowser(passphraseLink)}>documentation</ActionLink>
         <span> to learn about it.</span>

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -33,7 +33,7 @@ const passphraseLink = 'https://wiki.alephium.org/wallet/Desktop-Wallet-Guide#pa
 
 const WalletPassphrase = ({ value, onChange }: Props) => (
   <ExpandableSection sectionTitleClosed="Optional passphrase (advanced)" centered>
-    <InfoBox noMarginBottom importance="alert">
+    <InfoBox importance="alert">
       <p>
         <WarningEmphasis>This is an advanced feature! </WarningEmphasis>
         <br />

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import ExpandableSection from '../ExpandableSection'
+import InfoBox from '../InfoBox'
 import Input from './Input'
 
 interface Props {
@@ -26,13 +27,15 @@ interface Props {
 
 const WalletPassphrase = ({ value, onChange }: Props) => (
   <ExpandableSection sectionTitleClosed="Optional passphrase" centered>
-    <p>The software will derive or &quot;find&quot; a wallet based on the passphrase entered below.</p>
-    <p>
-      <strong>An incorrect passphrase could generate a wallet with zero funds.</strong>
-      <span> Do not panic, this is normal! Calmly try again.</span>
-    </p>
-    <p>Addresses need to be re-discovered to see all funds after unlocking.</p>
-    <Input value={value} label="Optional passphrase" type="password" onChange={(e) => onChange(e.target.value)} />
+    <InfoBox noMarginBottom>
+      <p>The software will derive or &quot;find&quot; a wallet based on the passphrase entered below.</p>
+      <p>
+        <strong>This is an advanced feature!</strong>
+        <span> Before using it, please take some time to learn more about it in our wiki.</span>
+      </p>
+      <p>Addresses need to be re-discovered to see all funds after unlocking.</p>
+      <Input value={value} label="Optional passphrase" type="password" onChange={(e) => onChange(e.target.value)} />
+    </InfoBox>
   </ExpandableSection>
 )
 

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { FC } from 'react'
 import styled from 'styled-components'
 
 import { openInWebBrowser } from '../../utils/misc'
@@ -27,19 +28,20 @@ import Input from './Input'
 interface Props {
   value: string
   onChange: (passphrase: string) => void
+  className?: string
 }
 
-const passphraseLink = 'https://wiki.alephium.org/wallet/Desktop-Wallet-Guide#passphrase'
-
-const WalletPassphrase = ({ value, onChange }: Props) => (
-  <ExpandableSection sectionTitleClosed="Optional passphrase (advanced)" centered>
+const WalletPassphrase = ({ value, onChange, className }: Props) => (
+  <ExpandableSection sectionTitleClosed="Optional passphrase (advanced)" centered className={className}>
     <InfoBox importance="alert">
       <p>
         <WarningEmphasis>This is an advanced feature! </WarningEmphasis>
         <br />
-        <span>Use it only if you know what you are doing. Please, consult our </span>
-        <ActionLink onClick={() => openInWebBrowser(passphraseLink)}>documentation</ActionLink>
-        <span> to learn about it.</span>
+        <span>Use it only if you know what you are doing.</span>
+        <br />
+        <span>
+          Please, consult our <Link>documentation</Link> to learn about it.
+        </span>
       </p>
     </InfoBox>
     <Input value={value} label="Optional passphrase" type="password" onChange={(e) => onChange(e.target.value)} />
@@ -50,4 +52,12 @@ const WarningEmphasis = styled.strong`
   color: ${({ theme }) => theme.global.alert};
 `
 
-export default WalletPassphrase
+const Link: FC = ({ children }) => (
+  <ActionLink onClick={() => openInWebBrowser('https://wiki.alephium.org/wallet/Desktop-Wallet-Guide#passphrase')}>
+    {children}
+  </ActionLink>
+)
+
+export default styled(WalletPassphrase)`
+  max-width: 400px;
+`

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -16,6 +16,9 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { AlertTriangle } from 'lucide-react'
+import styled from 'styled-components'
+
 import { openInWebBrowser } from '../../utils/misc'
 import ActionLink from '../ActionLink'
 import ExpandableSection from '../ExpandableSection'
@@ -30,21 +33,24 @@ interface Props {
 const passphraseLink = 'https://wiki.alephium.org/wallet/Desktop-Wallet-Guide#passphrase'
 
 const WalletPassphrase = ({ value, onChange }: Props) => (
-  <ExpandableSection sectionTitleClosed="Optional passphrase" centered>
-    <InfoBox noMarginBottom>
-      <p>The software will derive or &quot;find&quot; a wallet based on the passphrase entered below.</p>
-      <p>
-        <strong>This is an advanced feature!</strong>
-        <span>
-          {' '}
-          Before using it, please take some time to{' '}
-          <ActionLink onClick={() => openInWebBrowser(passphraseLink)}>learn more about it</ActionLink> in our wiki.
-        </span>
-      </p>
-      <p>Addresses need to be re-discovered to see all funds after unlocking.</p>
-      <Input value={value} label="Optional passphrase" type="password" onChange={(e) => onChange(e.target.value)} />
+  <ExpandableSection sectionTitleClosed="Optional passphrase (advanced)" centered>
+    <InfoBox noMarginBottom importance="alert" Icon={AlertTriangle}>
+      <WarningEmphasis>This is an advanced feature!</WarningEmphasis>
+      <br />
+      <span>
+        {' '}
+        Before using it, please take some time to{' '}
+        <ActionLink onClick={() => openInWebBrowser(passphraseLink)}>learn more about it</ActionLink> in our wiki.
+      </span>
+      <br />
+      <span>Addresses need to be re-discovered to see all funds after unlocking.</span>
     </InfoBox>
+    <Input value={value} label="Optional passphrase" type="password" onChange={(e) => onChange(e.target.value)} />
   </ExpandableSection>
 )
+
+const WarningEmphasis = styled.strong`
+  color: ${({ theme }) => theme.global.alert};
+`
 
 export default WalletPassphrase

--- a/src/components/OverviewPage/TransactionList.tsx
+++ b/src/components/OverviewPage/TransactionList.tsx
@@ -44,7 +44,7 @@ interface OverviewPageTransactionListProps {
 const OverviewPageTransactionList = ({ className, onTransactionClick }: OverviewPageTransactionListProps) => {
   const { addresses, fetchAddressTransactionsNextPage, isLoadingData } = useAddressesContext()
   const totalNumberOfTransactions = addresses.map((address) => address.details.txNumber).reduce((a, b) => a + b, 0)
-  const { passphraseHash } = useGlobalContext()
+  const { isPassphraseUsed } = useGlobalContext()
 
   const allConfirmedTxs = addresses
     .map((address) => address.transactions.confirmed.map((tx) => ({ ...tx, address })))
@@ -74,7 +74,7 @@ const OverviewPageTransactionList = ({ className, onTransactionClick }: Overview
             </TableCell>
             <TableCell>{dayjs(timestamp).fromNow()}</TableCell>
             <TableCell>
-              <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} />
+              <AddressBadge color={address.settings.color} addressName={address.getLabelName(!isPassphraseUsed)} />
             </TableCell>
             <TableCell align="end">
               {type === 'transfer' && amount && <TransactionalInfo type="out" prefix="-" content={amount} amount />}
@@ -100,7 +100,7 @@ const OverviewPageTransactionList = ({ className, onTransactionClick }: Overview
               <AddressBadge
                 color={transaction.address.settings.color}
                 truncate
-                addressName={transaction.address.getLabelName(!passphraseHash)}
+                addressName={transaction.address.getLabelName(!isPassphraseUsed)}
               />
             </TableCell>
             <TableCell align="end">

--- a/src/components/OverviewPage/TransactionList.tsx
+++ b/src/components/OverviewPage/TransactionList.tsx
@@ -25,6 +25,7 @@ import AddressBadge from '../../components/AddressBadge'
 import Table, { TableCell, TableCellPlaceholder, TableProps, TableRow } from '../../components/Table'
 import TransactionalInfo from '../../components/TransactionalInfo'
 import { Address, useAddressesContext } from '../../contexts/addresses'
+import { useGlobalContext } from '../../contexts/global'
 
 const transactionsTableHeaders: TableProps['headers'] = [
   { title: 'Direction', width: '100px' },
@@ -43,6 +44,7 @@ interface OverviewPageTransactionListProps {
 const OverviewPageTransactionList = ({ className, onTransactionClick }: OverviewPageTransactionListProps) => {
   const { addresses, fetchAddressTransactionsNextPage, isLoadingData } = useAddressesContext()
   const totalNumberOfTransactions = addresses.map((address) => address.details.txNumber).reduce((a, b) => a + b, 0)
+  const { passphraseHash } = useGlobalContext()
 
   const allConfirmedTxs = addresses
     .map((address) => address.transactions.confirmed.map((tx) => ({ ...tx, address })))
@@ -72,7 +74,7 @@ const OverviewPageTransactionList = ({ className, onTransactionClick }: Overview
             </TableCell>
             <TableCell>{dayjs(timestamp).fromNow()}</TableCell>
             <TableCell>
-              <AddressBadge color={address.settings.color} addressName={address.getLabelName()} />
+              <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} />
             </TableCell>
             <TableCell align="end">
               {type === 'transfer' && amount && <TransactionalInfo type="out" prefix="-" content={amount} amount />}
@@ -98,7 +100,7 @@ const OverviewPageTransactionList = ({ className, onTransactionClick }: Overview
               <AddressBadge
                 color={transaction.address.settings.color}
                 truncate
-                addressName={transaction.address.getLabelName()}
+                addressName={transaction.address.getLabelName(!passphraseHash)}
               />
             </TableCell>
             <TableCell align="end">

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -17,7 +17,8 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { getStorage, walletOpen } from '@alephium/sdk'
-import { useState } from 'react'
+import { FC, useState } from 'react'
+import styled from 'styled-components'
 
 import { useGlobalContext } from '../contexts/global'
 import Button from './Button'
@@ -33,11 +34,12 @@ interface PasswordConfirmationProps {
   walletName?: string
 }
 
-const PasswordConfirmation = ({
+const PasswordConfirmation: FC<PasswordConfirmationProps> = ({
   text,
   buttonText,
   onCorrectPasswordEntered,
-  walletName
+  walletName,
+  children
 }: PasswordConfirmationProps) => {
   const { activeWalletName, setSnackbarMessage } = useGlobalContext()
   const [password, setPassword] = useState('')
@@ -58,6 +60,7 @@ const PasswordConfirmation = ({
     <>
       <Section>
         <Input value={password} label={text} type="password" onChange={(e) => setPassword(e.target.value)} autoFocus />
+        {children && <Children>{children}</Children>}
       </Section>
       <Section>
         <Button onClick={validatePassword} submit wide>
@@ -69,3 +72,7 @@ const PasswordConfirmation = ({
 }
 
 export default PasswordConfirmation
+
+const Children = styled.div`
+  margin-bottom: 1rem;
+`

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -40,7 +40,7 @@ const PasswordConfirmation: FC<PasswordConfirmationProps> = ({
   onCorrectPasswordEntered,
   walletName,
   children
-}: PasswordConfirmationProps) => {
+}) => {
   const { activeWalletName, setSnackbarMessage } = useGlobalContext()
   const [password, setPassword] = useState('')
 

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -75,4 +75,5 @@ export default PasswordConfirmation
 
 const Children = styled.div`
   margin-bottom: 1rem;
+  width: 100%;
 `

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -34,7 +34,7 @@ import {
   loadStoredAddressesMetadataOfAccount,
   storeAddressMetadataOfAccount
 } from '../utils/addresses'
-import { stringToDoubleSHA215HexString } from '../utils/misc'
+import { stringToDoubleSHA256HexString } from '../utils/misc'
 import { NetworkName } from '../utils/settings'
 import { useGlobalContext } from './global'
 
@@ -186,7 +186,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   )
 
   const getAccountKey = useCallback(
-    () => stringToDoubleSHA215HexString(`${currentAccountName}-${passphraseDoubleHashed}`),
+    () => stringToDoubleSHA256HexString(`${currentAccountName}-${passphraseDoubleHashed}`),
     [currentAccountName, passphraseDoubleHashed]
   )
 

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -212,13 +212,15 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const updateAddressSettings = useCallback(
     (address: Address, settings: AddressSettings) => {
       if (!wallet) return
-      storeAddressMetadataOfWallet({
-        mnemonic: wallet.mnemonic,
-        activeWalletName: activeWalletName,
-        index: address.index,
-        settings,
-        passphraseHash
-      })
+      storeAddressMetadataOfWallet(
+        {
+          mnemonic: wallet.mnemonic,
+          walletName: activeWalletName,
+          passphraseHash
+        },
+        address.index,
+        settings
+      )
       address.settings = settings
       setAddress(address)
     },
@@ -294,13 +296,15 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const saveNewAddress = useCallback(
     (newAddress: Address) => {
       if (!wallet) return
-      storeAddressMetadataOfWallet({
-        mnemonic: wallet.mnemonic,
-        walletName: activeWalletName,
-        index: newAddress.index,
-        settings: newAddress.settings,
-        passphraseHash
-      })
+      storeAddressMetadataOfWallet(
+        {
+          mnemonic: wallet.mnemonic,
+          walletName: activeWalletName,
+          passphraseHash
+        },
+        newAddress.index,
+        newAddress.settings
+      )
       setAddress(newAddress)
       fetchAndStoreAddressesData([newAddress])
     },
@@ -377,17 +381,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       initializeCurrentNetworkAddresses()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    currentNetwork,
-    networkStatus,
-    client,
-    activeWalletName,
-    getAccountKey,
-    wallet,
-    explorerApiHost,
-    nodeHost,
-    usedPassphrase
-  ])
+  }, [currentNetwork, networkStatus, client, activeWalletName, wallet, explorerApiHost, nodeHost])
 
   // Whenever the addresses state updates, check if there are pending transactions on the current network and if so,
   // keep querying the API until all pending transactions are confirmed.

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -34,7 +34,6 @@ import {
   loadStoredAddressesMetadataOfAccount,
   storeAddressMetadataOfAccount
 } from '../utils/addresses'
-import { stringToDoubleSHA256HexString } from '../utils/misc'
 import { NetworkName } from '../utils/settings'
 import { useGlobalContext } from './global'
 
@@ -217,11 +216,17 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const updateAddressSettings = useCallback(
     (address: Address, settings: AddressSettings) => {
       if (!wallet) return
-      storeAddressMetadataOfAccount(wallet.mnemonic, activeWalletName, passphraseHash, address.index, settings)
+      storeAddressMetadataOfWallet({
+        mnemonic: wallet.mnemonic,
+        activeWalletName: activeWalletName,
+        index: address.index,
+        settings,
+        passphraseHash
+      })
       address.settings = settings
       setAddress(address)
     },
-    [setAddress, wallet]
+    [setAddress, wallet, currentAccountName, passphraseHash]
   )
 
   const fetchAndStoreAddressesData = useCallback(
@@ -293,11 +298,17 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const saveNewAddress = useCallback(
     (newAddress: Address) => {
       if (!wallet) return
-      storeAddressMetadataOfAccount(wallet.mnemonic, activeWalletName, passphraseHash, newAddress.index, newAddress.settings)
+      storeAddressMetadataOfWallet({
+        mnemonic: wallet.mnemonic,
+        walletName: activeWalletName,
+        index: newAddress.index,
+        settings: newAddress.settings,
+        passphraseHash
+      })
       setAddress(newAddress)
       fetchAndStoreAddressesData([newAddress])
     },
-    [fetchAndStoreAddressesData, setAddress, wallet]
+    [fetchAndStoreAddressesData, setAddress, wallet, currentAccountName, passphraseHash]
   )
 
   const generateOneAddressPerGroup = (labelPrefix: string, labelColor: string, skipGroups: number[] = []) => {
@@ -324,7 +335,11 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       console.log('🥇 Initializing current network addresses')
       if (!activeWalletName || !wallet) return
 
-      const addressesMetadata = loadStoredAddressesMetadataOfAccount(wallet.mnemonic, activeWalletName, passphraseHash)
+      const addressesMetadata = loadStoredAddressesMetadataOfAccount({
+        mnemonic: wallet.mnemonic,
+        walletName: activeWalletName,
+        passphraseHash
+      })
 
       if (addressesMetadata.length === 0) {
         saveNewAddress(

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -162,7 +162,8 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
     settings: {
       network: { nodeHost, explorerApiHost }
     },
-    networkStatus
+    networkStatus,
+    usedPassphrase
   } = useGlobalContext()
   const previousWallet = useRef<Wallet | undefined>(wallet)
   const previousNodeApiHost = useRef<string>()
@@ -315,7 +316,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
 
       const addressesMetadata = loadStoredAddressesMetadataOfWallet(activeWalletName)
 
-      if (addressesMetadata.length === 0) {
+      if (usedPassphrase || addressesMetadata.length === 0) {
         saveNewAddress(
           new Address(wallet.address, wallet.publicKey, wallet.privateKey, 0, {
             isMain: true,
@@ -355,7 +356,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       initializeCurrentNetworkAddresses()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentNetwork, networkStatus, client, activeWalletName, wallet, explorerApiHost, nodeHost])
+  }, [currentNetwork, networkStatus, client, activeWalletName, wallet, explorerApiHost, nodeHost, usedPassphrase])
 
   // Whenever the addresses state updates, check if there are pending transactions on the current network and if so,
   // keep querying the API until all pending transactions are confirmed.

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -91,8 +91,8 @@ export class Address {
     return this.settings.label || this.shortHash
   }
 
-  getLabelName() {
-    return `${this.settings.isMain ? '★ ' : ''}${this.getName()}`
+  getLabelName(showStar = true) {
+    return `${this.settings.isMain && showStar ? '★ ' : ''}${this.getName()}`
   }
 
   addPendingTransaction(transaction: SimpleTx) {
@@ -128,7 +128,7 @@ export interface AddressesContextProps {
   updateAddressSettings: (address: Address, settings: AddressSettings) => void
   refreshAddressesData: () => void
   fetchAddressTransactionsNextPage: (address: Address) => void
-  generateOneAddressPerGroup: (labelPrefix: string, color: string, skipGroups?: number[]) => void
+  generateOneAddressPerGroup: (labelPrefix?: string, color?: string, skipGroups?: number[]) => void
   isLoadingData: boolean
 }
 
@@ -311,10 +311,11 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
     [fetchAndStoreAddressesData, setAddress, wallet, activeWalletName, passphraseHash]
   )
 
-  const generateOneAddressPerGroup = (labelPrefix: string, labelColor: string, skipGroups: number[] = []) => {
+  const generateOneAddressPerGroup = (labelPrefix?: string, labelColor?: string, skipGroups: number[] = []) => {
     if (!wallet?.seed) return
 
     const skipAddressIndexes = addressesOfCurrentNetwork.map(({ index }) => index)
+    const hasLabel = !!labelPrefix && !!labelColor
     Array.from({ length: TOTAL_NUMBER_OF_GROUPS }, (_, group) => group)
       .filter((group) => !skipGroups.includes(group))
       .map((group) => ({ ...deriveNewAddressData(wallet.seed, group, undefined, skipAddressIndexes), group }))
@@ -322,8 +323,8 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
         saveNewAddress(
           new Address(address.address, address.publicKey, address.privateKey, address.addressIndex, {
             isMain: false,
-            label: `${labelPrefix} ${address.group}`,
-            color: labelColor
+            label: hasLabel ? `${labelPrefix} ${address.group}` : '',
+            color: hasLabel ? labelColor : ''
           })
         )
       })

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -163,7 +163,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       network: { nodeHost, explorerApiHost }
     },
     networkStatus,
-    passphraseHash
+    isPassphraseUsed
   } = useGlobalContext()
   const previousWallet = useRef<Wallet | undefined>(wallet)
   const previousNodeApiHost = useRef<string>()
@@ -212,19 +212,20 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const updateAddressSettings = useCallback(
     (address: Address, settings: AddressSettings) => {
       if (!wallet) return
-      storeAddressMetadataOfWallet(
-        {
-          mnemonic: wallet.mnemonic,
-          walletName: activeWalletName,
-          passphraseHash
-        },
-        address.index,
-        settings
-      )
+
+      if (!isPassphraseUsed)
+        storeAddressMetadataOfWallet(
+          {
+            mnemonic: wallet.mnemonic,
+            walletName: activeWalletName
+          },
+          address.index,
+          settings
+        )
       address.settings = settings
       setAddress(address)
     },
-    [setAddress, wallet, activeWalletName, passphraseHash]
+    [wallet, activeWalletName, isPassphraseUsed, setAddress]
   )
 
   const fetchAndStoreAddressesData = useCallback(
@@ -296,19 +297,20 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const saveNewAddress = useCallback(
     (newAddress: Address) => {
       if (!wallet) return
-      storeAddressMetadataOfWallet(
-        {
-          mnemonic: wallet.mnemonic,
-          walletName: activeWalletName,
-          passphraseHash
-        },
-        newAddress.index,
-        newAddress.settings
-      )
+
+      if (!isPassphraseUsed)
+        storeAddressMetadataOfWallet(
+          {
+            mnemonic: wallet.mnemonic,
+            walletName: activeWalletName
+          },
+          newAddress.index,
+          newAddress.settings
+        )
       setAddress(newAddress)
       fetchAndStoreAddressesData([newAddress])
     },
-    [fetchAndStoreAddressesData, setAddress, wallet, activeWalletName, passphraseHash]
+    [wallet, isPassphraseUsed, activeWalletName, setAddress, fetchAndStoreAddressesData]
   )
 
   const generateOneAddressPerGroup = (labelPrefix?: string, labelColor?: string, skipGroups: number[] = []) => {
@@ -336,11 +338,12 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       console.log('🥇 Initializing current network addresses')
       if (!activeWalletName || !wallet) return
 
-      const addressesMetadata = loadStoredAddressesMetadataOfWallet({
-        mnemonic: wallet.mnemonic,
-        walletName: activeWalletName,
-        passphraseHash
-      })
+      const addressesMetadata = isPassphraseUsed
+        ? []
+        : loadStoredAddressesMetadataOfWallet({
+            mnemonic: wallet.mnemonic,
+            walletName: activeWalletName
+          })
 
       if (addressesMetadata.length === 0) {
         saveNewAddress(

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -29,9 +29,13 @@ import { createContext, FC, useCallback, useContext, useEffect, useRef, useState
 import { PartialDeep } from 'type-fest'
 
 import { TimeInMs } from '../types/numbers'
-import { AddressSettings, loadStoredAddressesMetadataOfWallet, storeAddressMetadataOfWallet } from '../utils/addresses'
-import { NetworkName } from '../utils/settings'
+import {
+  AddressSettings,
+  loadStoredAddressesMetadataOfAccount,
+  storeAddressMetadataOfAccount
+} from '../utils/addresses'
 import { stringToDoubleSHA215HexString } from '../utils/misc'
+import { NetworkName } from '../utils/settings'
 import { useGlobalContext } from './global'
 
 export type TransactionType = 'consolidation' | 'transfer' | 'sweep'

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -29,11 +29,7 @@ import { createContext, FC, useCallback, useContext, useEffect, useRef, useState
 import { PartialDeep } from 'type-fest'
 
 import { TimeInMs } from '../types/numbers'
-import {
-  AddressSettings,
-  loadStoredAddressesMetadataOfAccount,
-  storeAddressMetadataOfAccount
-} from '../utils/addresses'
+import { AddressSettings, loadStoredAddressesMetadataOfWallet, storeAddressMetadataOfWallet } from '../utils/addresses'
 import { NetworkName } from '../utils/settings'
 import { useGlobalContext } from './global'
 
@@ -226,7 +222,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       address.settings = settings
       setAddress(address)
     },
-    [setAddress, wallet, currentAccountName, passphraseHash]
+    [setAddress, wallet, activeWalletName, passphraseHash]
   )
 
   const fetchAndStoreAddressesData = useCallback(
@@ -308,7 +304,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       setAddress(newAddress)
       fetchAndStoreAddressesData([newAddress])
     },
-    [fetchAndStoreAddressesData, setAddress, wallet, currentAccountName, passphraseHash]
+    [fetchAndStoreAddressesData, setAddress, wallet, activeWalletName, passphraseHash]
   )
 
   const generateOneAddressPerGroup = (labelPrefix: string, labelColor: string, skipGroups: number[] = []) => {
@@ -335,7 +331,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       console.log('🥇 Initializing current network addresses')
       if (!activeWalletName || !wallet) return
 
-      const addressesMetadata = loadStoredAddressesMetadataOfAccount({
+      const addressesMetadata = loadStoredAddressesMetadataOfWallet({
         mnemonic: wallet.mnemonic,
         walletName: activeWalletName,
         passphraseHash
@@ -381,7 +377,17 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       initializeCurrentNetworkAddresses()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentNetwork, networkStatus, client, activeWalletName, getAccountKey, wallet, explorerApiHost, nodeHost, usedPassphrase])
+  }, [
+    currentNetwork,
+    networkStatus,
+    client,
+    activeWalletName,
+    getAccountKey,
+    wallet,
+    explorerApiHost,
+    nodeHost,
+    usedPassphrase
+  ])
 
   // Whenever the addresses state updates, check if there are pending transactions on the current network and if so,
   // keep querying the API until all pending transactions are confirmed.

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -221,11 +221,12 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
 
   const updateAddressSettings = useCallback(
     (address: Address, settings: AddressSettings) => {
-      storeAddressMetadataOfAccount(getAccountKey(), address.index, settings)
+      if (!wallet) return
+      storeAddressMetadataOfAccount(wallet.mnemonic, getAccountKey(), address.index, settings)
       address.settings = settings
       setAddress(address)
     },
-    [getAccountKey, setAddress]
+    [getAccountKey, setAddress, wallet]
   )
 
   const fetchAndStoreAddressesData = useCallback(
@@ -296,11 +297,12 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
 
   const saveNewAddress = useCallback(
     (newAddress: Address) => {
-      storeAddressMetadataOfAccount(getAccountKey(), newAddress.index, newAddress.settings)
+      if (!wallet) return
+      storeAddressMetadataOfAccount(wallet.mnemonic, getAccountKey(), newAddress.index, newAddress.settings)
       setAddress(newAddress)
       fetchAndStoreAddressesData([newAddress])
     },
-    [getAccountKey, fetchAndStoreAddressesData, setAddress]
+    [getAccountKey, fetchAndStoreAddressesData, setAddress, wallet]
   )
 
   const generateOneAddressPerGroup = (labelPrefix: string, labelColor: string, skipGroups: number[] = []) => {
@@ -327,7 +329,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       console.log('🥇 Initializing current network addresses')
       if (!activeWalletName || !wallet) return
 
-      const addressesMetadata = loadStoredAddressesMetadataOfAccount(getAccountKey())
+      const addressesMetadata = loadStoredAddressesMetadataOfAccount(wallet.mnemonic, getAccountKey())
 
       if (addressesMetadata.length === 0) {
         saveNewAddress(

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -168,7 +168,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       network: { nodeHost, explorerApiHost }
     },
     networkStatus,
-    passphraseDoubleHashed
+    passphraseHash
   } = useGlobalContext()
   const previousWallet = useRef<Wallet | undefined>(wallet)
   const previousNodeApiHost = useRef<string>()
@@ -183,11 +183,6 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const constructMapKey = useCallback(
     (addressHash: AddressHash) => `${addressHash}-${currentNetwork}`,
     [currentNetwork]
-  )
-
-  const getAccountKey = useCallback(
-    () => stringToDoubleSHA256HexString(`${currentAccountName}-${passphraseDoubleHashed}`),
-    [currentAccountName, passphraseDoubleHashed]
   )
 
   const getAddress = useCallback(
@@ -222,11 +217,11 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const updateAddressSettings = useCallback(
     (address: Address, settings: AddressSettings) => {
       if (!wallet) return
-      storeAddressMetadataOfAccount(wallet.mnemonic, getAccountKey(), address.index, settings)
+      storeAddressMetadataOfAccount(wallet.mnemonic, activeWalletName, passphraseHash, address.index, settings)
       address.settings = settings
       setAddress(address)
     },
-    [getAccountKey, setAddress, wallet]
+    [setAddress, wallet]
   )
 
   const fetchAndStoreAddressesData = useCallback(
@@ -298,11 +293,11 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const saveNewAddress = useCallback(
     (newAddress: Address) => {
       if (!wallet) return
-      storeAddressMetadataOfAccount(wallet.mnemonic, getAccountKey(), newAddress.index, newAddress.settings)
+      storeAddressMetadataOfAccount(wallet.mnemonic, activeWalletName, passphraseHash, newAddress.index, newAddress.settings)
       setAddress(newAddress)
       fetchAndStoreAddressesData([newAddress])
     },
-    [getAccountKey, fetchAndStoreAddressesData, setAddress, wallet]
+    [fetchAndStoreAddressesData, setAddress, wallet]
   )
 
   const generateOneAddressPerGroup = (labelPrefix: string, labelColor: string, skipGroups: number[] = []) => {
@@ -329,7 +324,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       console.log('🥇 Initializing current network addresses')
       if (!activeWalletName || !wallet) return
 
-      const addressesMetadata = loadStoredAddressesMetadataOfAccount(wallet.mnemonic, getAccountKey())
+      const addressesMetadata = loadStoredAddressesMetadataOfAccount(wallet.mnemonic, activeWalletName, passphraseHash)
 
       if (addressesMetadata.length === 0) {
         saveNewAddress(

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -136,13 +136,15 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
     try {
       let wallet = walletOpen(password, walletEncrypted)
       if (!wallet) return
+
+      let _passphraseHash = passphraseHash
       if (passphrase) {
-        wallet = getWalletFromMnemonic(`${wallet.mnemonic} ${passphrase}`)
-        const _passphraseHash = stringToDoubleSHA256HexString(passphrase)
+        wallet = getWalletFromMnemonic(wallet.mnemonic, passphrase)
+        _passphraseHash = stringToDoubleSHA256HexString(passphrase)
         setPassphraseHash(_passphraseHash)
       }
 
-      migrateUserData(wallet.mnemonic, accountName)
+      migrateUserData(wallet.mnemonic, accountName, _passphraseHash)
 
       // Based on the user opening the wallet once a week (52 / 4 = 13)
       // It will roll a die between 1 and 13 and if it lands on 1, new address metadata is created

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -28,7 +28,7 @@ import { NetworkStatus } from '../types/network'
 import { letSneakyAddressMetadataImpLoose } from '../utils/addresses'
 import { createClient } from '../utils/api-clients'
 import { migrateUserData } from '../utils/migration'
-import { stringToDoubleSHA215HexString } from '../utils/misc'
+import { stringToDoubleSHA512HexString } from '../utils/misc'
 import {
   deprecatedSettingsExist,
   getNetworkName,
@@ -143,7 +143,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
       if (!wallet) return
       if (passphrase) {
         wallet = getWalletFromMnemonic(`${wallet.mnemonic} ${passphrase}`)
-        const _passphraseDoubleHashed = stringToDoubleSHA215HexString(passphrase)
+        const _passphraseDoubleHashed = stringToDoubleSHA512HexString(passphrase)
         setPassphraseDoubleHashed(_passphraseDoubleHashed)
       }
 

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -53,7 +53,7 @@ export interface GlobalContextProps {
   wallet?: Wallet
   setWallet: (w: Wallet | undefined) => void
   lockWallet: () => void
-  login: (accountName: string, password: string, callback: () => void, passphrase?: string) => void
+  login: (walletName: string, password: string, callback: () => void, passphrase?: string) => void
   client: Client | undefined
   settings: Settings
   updateSettings: UpdateSettingsFunctionSignature
@@ -127,8 +127,8 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
     setWallet(undefined)
   }
 
-  const login = async (accountName: string, password: string, callback: () => void, passphrase?: string) => {
-    const walletEncrypted = Storage.load(accountName)
+  const login = async (walletName: string, password: string, callback: () => void, passphrase?: string) => {
+    const walletEncrypted = Storage.load(walletName)
     if (!walletEncrypted) {
       setSnackbarMessage({ text: 'Unknown wallet name', type: 'alert' })
       return
@@ -144,7 +144,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
         setPassphraseHash(_passphraseHash)
       }
 
-      migrateUserData(wallet.mnemonic, accountName, _passphraseHash)
+      migrateUserData(wallet.mnemonic, walletName, _passphraseHash)
 
       // Based on the user opening the wallet once a week (52 / 4 = 13)
       // It will roll a die between 1 and 13 and if it lands on 1, new address metadata is created

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -25,7 +25,6 @@ import { SnackbarMessage } from '../components/SnackbarManager'
 import useIdleForTooLong from '../hooks/useIdleForTooLong'
 import useLatestGitHubRelease from '../hooks/useLatestGitHubRelease'
 import { NetworkStatus } from '../types/network'
-import { letSneakyAddressMetadataImpLoose } from '../utils/addresses'
 import { createClient } from '../utils/api-clients'
 import { migrateUserData } from '../utils/migration'
 import { stringToDoubleSHA256HexString } from '../utils/misc'
@@ -145,11 +144,6 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
       }
 
       migrateUserData(wallet.mnemonic, walletName, _passphraseHash)
-
-      // Based on the user opening the wallet five times a week and having a 1/4 chance of dummy metadata (52 * 5 / 4 = 65)
-      // It will roll a die between 1 and 65 and if it lands on 1, new address metadata is created
-      // Set first argument to 1 if you want it to generate new address metadata each time
-      letSneakyAddressMetadataImpLoose(65, wallet.mnemonic)
 
       setWallet(wallet)
       setCurrentWalletName(walletName)

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -26,6 +26,7 @@ import useIdleForTooLong from '../hooks/useIdleForTooLong'
 import useLatestGitHubRelease from '../hooks/useLatestGitHubRelease'
 import { NetworkStatus } from '../types/network'
 import { createClient } from '../utils/api-clients'
+import { stringToDoubleSHA215HexString } from '../utils/misc'
 import {
   deprecatedSettingsExist,
   getNetworkName,
@@ -61,7 +62,7 @@ export interface GlobalContextProps {
   networkStatus: NetworkStatus
   updateNetworkSettings: (settings: Settings['network']) => void
   newLatestVersion: string
-  usedPassphrase: boolean
+  passphraseDoubleHashed: string
 }
 
 export type Client = AsyncReturnType<typeof createClient>
@@ -83,7 +84,7 @@ export const initialGlobalContext: GlobalContextProps = {
   networkStatus: 'uninitialized',
   updateNetworkSettings: () => null,
   newLatestVersion: '',
-  usedPassphrase: false
+  passphraseDoubleHashed: ''
 }
 
 export const GlobalContext = createContext<GlobalContextProps>(initialGlobalContext)
@@ -103,7 +104,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
   const previousNodeHost = useRef<string>()
   const previousExplorerAPIHost = useRef<string>()
   const [networkStatus, setNetworkStatus] = useState<NetworkStatus>('uninitialized')
-  const [usedPassphrase, setUsedPassphrase] = useState(false)
+  const [passphraseDoubleHashed, setPassphraseDoubleHashed] = useState('')
   const currentNetwork = getNetworkName(settings.network)
   const newLatestVersion = useLatestGitHubRelease()
 
@@ -119,8 +120,13 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
   }
 
   const lockWallet = () => {
+<<<<<<< HEAD
     setCurrentWalletName('')
     setUsedPassphrase(false)
+=======
+    setPassphraseDoubleHashed('')
+    setCurrentAccountName('')
+>>>>>>> 232d72f (Support labels for derived wallets)
     setWallet(undefined)
   }
 
@@ -135,7 +141,8 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
       if (!wallet) return
       if (passphrase) {
         wallet = getWalletFromMnemonic(`${wallet.mnemonic} ${passphrase}`)
-        setUsedPassphrase(true)
+        const _passphraseDoubleHashed = stringToDoubleSHA215HexString(passphrase)
+        setPassphraseDoubleHashed(_passphraseDoubleHashed)
       }
       setWallet(wallet)
       setCurrentWalletName(walletName)
@@ -220,7 +227,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
           networkStatus,
           updateNetworkSettings,
           newLatestVersion,
-          usedPassphrase
+          passphraseDoubleHashed
         },
         overrideContextValue as GlobalContextProps
       )}

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -64,7 +64,7 @@ export interface GlobalContextProps {
   networkStatus: NetworkStatus
   updateNetworkSettings: (settings: Settings['network']) => void
   newLatestVersion: string
-  passphraseDoubleHashed: string
+  passphraseHash: string
 }
 
 export type Client = AsyncReturnType<typeof createClient>
@@ -86,7 +86,7 @@ export const initialGlobalContext: GlobalContextProps = {
   networkStatus: 'uninitialized',
   updateNetworkSettings: () => null,
   newLatestVersion: '',
-  passphraseDoubleHashed: ''
+  passphraseHash: ''
 }
 
 export const GlobalContext = createContext<GlobalContextProps>(initialGlobalContext)
@@ -106,7 +106,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
   const previousNodeHost = useRef<string>()
   const previousExplorerAPIHost = useRef<string>()
   const [networkStatus, setNetworkStatus] = useState<NetworkStatus>('uninitialized')
-  const [passphraseDoubleHashed, setPassphraseDoubleHashed] = useState('')
+  const [passphraseHash, setPassphraseHash] = useState('')
   const currentNetwork = getNetworkName(settings.network)
   const newLatestVersion = useLatestGitHubRelease()
 
@@ -143,8 +143,8 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
       if (!wallet) return
       if (passphrase) {
         wallet = getWalletFromMnemonic(`${wallet.mnemonic} ${passphrase}`)
-        const _passphraseDoubleHashed = stringToDoubleSHA256HexString(passphrase)
-        setPassphraseDoubleHashed(_passphraseDoubleHashed)
+        const _passphraseHash = stringToDoubleSHA256HexString(passphrase)
+        setPassphraseHash(_passphraseHash)
       }
 
       migrateUserData(wallet.mnemonic, accountName)
@@ -237,7 +237,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
           networkStatus,
           updateNetworkSettings,
           newLatestVersion,
-          passphraseDoubleHashed
+          passphraseHash
         },
         overrideContextValue as GlobalContextProps
       )}

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -146,10 +146,10 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
 
       migrateUserData(wallet.mnemonic, walletName, _passphraseHash)
 
-      // Based on the user opening the wallet once a week (52 / 4 = 13)
-      // It will roll a die between 1 and 13 and if it lands on 1, new address metadata is created
+      // Based on the user opening the wallet five times a week and having a 1/4 chance of dummy metadata (52 * 5 / 4 = 65)
+      // It will roll a die between 1 and 65 and if it lands on 1, new address metadata is created
       // Set first argument to 1 if you want it to generate new address metadata each time
-      letSneakyAddressMetadataImpLoose(13, wallet.mnemonic)
+      letSneakyAddressMetadataImpLoose(65, wallet.mnemonic)
 
       setWallet(wallet)
       setCurrentWalletName(walletName)

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { getStorage, Wallet, walletOpen } from '@alephium/sdk'
+import { getStorage, getWalletFromMnemonic, Wallet, walletOpen } from '@alephium/sdk'
 import { merge } from 'lodash'
 import { createContext, FC, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { AsyncReturnType, PartialDeep } from 'type-fest'
@@ -50,7 +50,7 @@ export interface GlobalContextProps {
   wallet?: Wallet
   setWallet: (w: Wallet | undefined) => void
   lockWallet: () => void
-  login: (walletName: string, password: string, callback: () => void) => void
+  login: (accountName: string, password: string, callback: () => void, passphrase?: string) => void
   client: Client | undefined
   settings: Settings
   updateSettings: UpdateSettingsFunctionSignature
@@ -120,14 +120,24 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
     setWallet(undefined)
   }
 
-  const login = async (walletName: string, password: string, callback: () => void) => {
-    const walletEncrypted = Storage.load(walletName)
+  const login = async (accountName: string, password: string, callback: () => void, passphrase?: string) => {
+    const walletEncrypted = Storage.load(accountName)
     if (!walletEncrypted) {
       setSnackbarMessage({ text: 'Unknown wallet name', type: 'alert' })
       return
     }
     try {
-      const wallet = walletOpen(password, walletEncrypted)
+      let wallet
+      if (passphrase) {
+        wallet = walletOpen(password, walletEncrypted)
+        let mnemonicFinal = wallet.mnemonic
+        if (passphrase) {
+          mnemonicFinal += ' ' + passphrase
+        }
+        wallet = getWalletFromMnemonic(mnemonicFinal)
+      } else {
+        wallet = walletOpen(password, walletEncrypted)
+      }
       if (!wallet) return
       setWallet(wallet)
       setCurrentWalletName(walletName)

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -122,13 +122,8 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
   }
 
   const lockWallet = () => {
-<<<<<<< HEAD
     setCurrentWalletName('')
-    setUsedPassphrase(false)
-=======
-    setPassphraseDoubleHashed('')
-    setCurrentAccountName('')
->>>>>>> 232d72f (Support labels for derived wallets)
+    setPassphraseHash('')
     setWallet(undefined)
   }
 

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -26,6 +26,7 @@ import useIdleForTooLong from '../hooks/useIdleForTooLong'
 import useLatestGitHubRelease from '../hooks/useLatestGitHubRelease'
 import { NetworkStatus } from '../types/network'
 import { createClient } from '../utils/api-clients'
+import { migrateUserData } from '../utils/migration'
 import { stringToDoubleSHA215HexString } from '../utils/misc'
 import {
   deprecatedSettingsExist,
@@ -144,6 +145,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
         const _passphraseDoubleHashed = stringToDoubleSHA215HexString(passphrase)
         setPassphraseDoubleHashed(_passphraseDoubleHashed)
       }
+      migrateUserData(password)
       setWallet(wallet)
       setCurrentWalletName(walletName)
       callback()

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -131,17 +131,12 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
       return
     }
     try {
-      let wallet
-      if (passphrase) {
-        wallet = walletOpen(password, walletEncrypted)
-        let mnemonicFinal = wallet.mnemonic
-        mnemonicFinal += ' ' + passphrase
-        wallet = getWalletFromMnemonic(mnemonicFinal)
-        setUsedPassphrase(true)
-      } else {
-        wallet = walletOpen(password, walletEncrypted)
-      }
+      let wallet = walletOpen(password, walletEncrypted)
       if (!wallet) return
+      if (passphrase) {
+        wallet = getWalletFromMnemonic(`${wallet.mnemonic} ${passphrase}`)
+        setUsedPassphrase(true)
+      }
       setWallet(wallet)
       setCurrentWalletName(walletName)
       callback()

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -28,7 +28,7 @@ import { NetworkStatus } from '../types/network'
 import { letSneakyAddressMetadataImpLoose } from '../utils/addresses'
 import { createClient } from '../utils/api-clients'
 import { migrateUserData } from '../utils/migration'
-import { stringToDoubleSHA512HexString } from '../utils/misc'
+import { stringToDoubleSHA256HexString } from '../utils/misc'
 import {
   deprecatedSettingsExist,
   getNetworkName,
@@ -143,7 +143,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
       if (!wallet) return
       if (passphrase) {
         wallet = getWalletFromMnemonic(`${wallet.mnemonic} ${passphrase}`)
-        const _passphraseDoubleHashed = stringToDoubleSHA512HexString(passphrase)
+        const _passphraseDoubleHashed = stringToDoubleSHA256HexString(passphrase)
         setPassphraseDoubleHashed(_passphraseDoubleHashed)
       }
 

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -25,6 +25,7 @@ import { SnackbarMessage } from '../components/SnackbarManager'
 import useIdleForTooLong from '../hooks/useIdleForTooLong'
 import useLatestGitHubRelease from '../hooks/useLatestGitHubRelease'
 import { NetworkStatus } from '../types/network'
+import { letSneakyAddressMetadataImpLoose } from '../utils/addresses'
 import { createClient } from '../utils/api-clients'
 import { migrateUserData } from '../utils/migration'
 import { stringToDoubleSHA215HexString } from '../utils/misc'
@@ -145,7 +146,14 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
         const _passphraseDoubleHashed = stringToDoubleSHA215HexString(passphrase)
         setPassphraseDoubleHashed(_passphraseDoubleHashed)
       }
+
       migrateUserData(password)
+
+      // Based on the user opening the wallet once a week (52 / 4 = 13)
+      // It will roll a die between 1 and 13 and if it lands on 1, new address metadata is created
+      // Set first argument to 1 if you want it to generate new address metadata each time
+      letSneakyAddressMetadataImpLoose(13, wallet.mnemonic)
+
       setWallet(wallet)
       setCurrentWalletName(walletName)
       callback()

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -147,7 +147,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
         setPassphraseDoubleHashed(_passphraseDoubleHashed)
       }
 
-      migrateUserData(password)
+      migrateUserData(wallet.mnemonic, accountName)
 
       // Based on the user opening the wallet once a week (52 / 4 = 13)
       // It will roll a die between 1 and 13 and if it lands on 1, new address metadata is created

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -61,6 +61,7 @@ export interface GlobalContextProps {
   networkStatus: NetworkStatus
   updateNetworkSettings: (settings: Settings['network']) => void
   newLatestVersion: string
+  usedPassphrase: boolean
 }
 
 export type Client = AsyncReturnType<typeof createClient>
@@ -81,7 +82,8 @@ export const initialGlobalContext: GlobalContextProps = {
   currentNetwork: 'mainnet',
   networkStatus: 'uninitialized',
   updateNetworkSettings: () => null,
-  newLatestVersion: ''
+  newLatestVersion: '',
+  usedPassphrase: false
 }
 
 export const GlobalContext = createContext<GlobalContextProps>(initialGlobalContext)
@@ -101,6 +103,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
   const previousNodeHost = useRef<string>()
   const previousExplorerAPIHost = useRef<string>()
   const [networkStatus, setNetworkStatus] = useState<NetworkStatus>('uninitialized')
+  const [usedPassphrase, setUsedPassphrase] = useState(false)
   const currentNetwork = getNetworkName(settings.network)
   const newLatestVersion = useLatestGitHubRelease()
 
@@ -117,6 +120,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
 
   const lockWallet = () => {
     setCurrentWalletName('')
+    setUsedPassphrase(false)
     setWallet(undefined)
   }
 
@@ -131,10 +135,9 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
       if (passphrase) {
         wallet = walletOpen(password, walletEncrypted)
         let mnemonicFinal = wallet.mnemonic
-        if (passphrase) {
-          mnemonicFinal += ' ' + passphrase
-        }
+        mnemonicFinal += ' ' + passphrase
         wallet = getWalletFromMnemonic(mnemonicFinal)
+        setUsedPassphrase(true)
       } else {
         wallet = walletOpen(password, walletEncrypted)
       }
@@ -221,7 +224,8 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
           currentNetwork,
           networkStatus,
           updateNetworkSettings,
-          newLatestVersion
+          newLatestVersion,
+          usedPassphrase
         },
         overrideContextValue as GlobalContextProps
       )}

--- a/src/contexts/wallet.tsx
+++ b/src/contexts/wallet.tsx
@@ -27,9 +27,9 @@ export interface WalletContextType {
   walletName: string
   setWalletName: (w: string) => void
   password: string
-  setPassword: Dispatch<SetStateAction<string>>
+  setPassword: (password: string) => void
   passphrase: string
-  setPassphrase: Dispatch<SetStateAction<string>>
+  setPassphrase: (password: string) => void
 }
 
 export const initialWalletContext: WalletContextType = {

--- a/src/contexts/wallet.tsx
+++ b/src/contexts/wallet.tsx
@@ -56,8 +56,8 @@ export const WalletContextProvider: FC = ({ children }) => {
   return (
     <WalletContext.Provider
       value={{
-        accountName,
-        setAccountName,
+        walletName,
+        setWalletName,
         password,
         setPassword,
         mnemonic,

--- a/src/contexts/wallet.tsx
+++ b/src/contexts/wallet.tsx
@@ -28,8 +28,6 @@ export interface WalletContextType {
   setWalletName: (w: string) => void
   password: string
   setPassword: (password: string) => void
-  passphrase: string
-  setPassphrase: (password: string) => void
 }
 
 export const initialWalletContext: WalletContextType = {
@@ -39,9 +37,7 @@ export const initialWalletContext: WalletContextType = {
   setWalletName: () => null,
   password: '',
   setPassword: () => null,
-  setPlainWallet: () => null,
-  passphrase: '',
-  setPassphrase: () => null
+  setPlainWallet: () => null
 }
 
 export const WalletContext = createContext<WalletContextType>(initialWalletContext)
@@ -51,7 +47,6 @@ export const WalletContextProvider: FC = ({ children }) => {
   const [password, setPassword] = useState('')
   const [plainWallet, setPlainWallet] = useState<Wallet>()
   const [mnemonic, setMnemonic] = useState('')
-  const [passphrase, setPassphrase] = useState('')
 
   return (
     <WalletContext.Provider
@@ -63,9 +58,7 @@ export const WalletContextProvider: FC = ({ children }) => {
         mnemonic,
         setMnemonic,
         plainWallet,
-        setPlainWallet,
-        passphrase,
-        setPassphrase
+        setPlainWallet
       }}
     >
       {children}

--- a/src/contexts/wallet.tsx
+++ b/src/contexts/wallet.tsx
@@ -27,7 +27,9 @@ export interface WalletContextType {
   walletName: string
   setWalletName: (w: string) => void
   password: string
-  setPassword: (p: string) => void
+  setPassword: Dispatch<SetStateAction<string>>
+  passphrase: string
+  setPassphrase: Dispatch<SetStateAction<string>>
 }
 
 export const initialWalletContext: WalletContextType = {
@@ -37,7 +39,9 @@ export const initialWalletContext: WalletContextType = {
   setWalletName: () => null,
   password: '',
   setPassword: () => null,
-  setPlainWallet: () => null
+  setPlainWallet: () => null,
+  passphrase: '',
+  setPassphrase: () => null
 }
 
 export const WalletContext = createContext<WalletContextType>(initialWalletContext)
@@ -47,10 +51,22 @@ export const WalletContextProvider: FC = ({ children }) => {
   const [password, setPassword] = useState('')
   const [plainWallet, setPlainWallet] = useState<Wallet>()
   const [mnemonic, setMnemonic] = useState('')
+  const [passphrase, setPassphrase] = useState('')
 
   return (
     <WalletContext.Provider
-      value={{ walletName, setWalletName, password, setPassword, mnemonic, setMnemonic, plainWallet, setPlainWallet }}
+      value={{
+        accountName,
+        setAccountName,
+        password,
+        setPassword,
+        mnemonic,
+        setMnemonic,
+        plainWallet,
+        setPlainWallet,
+        passphrase,
+        setPassphrase
+      }}
     >
       {children}
     </WalletContext.Provider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,9 +30,6 @@ import { GlobalContextProvider } from './contexts/global'
 import * as serviceWorker from './serviceWorker'
 import { GlobalStyle } from './style/globalStyles'
 import { lightTheme } from './style/themes'
-import { migrateAddressMetadata } from './utils/addresses'
-
-migrateAddressMetadata()
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/modals/AddressOptionsModal.tsx
+++ b/src/modals/AddressOptionsModal.tsx
@@ -42,7 +42,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
     color: address?.settings.color ?? getRandomLabelColor()
   })
   const [isMainAddress, setIsMainAddress] = useState(address?.settings.isMain ?? false)
-  const { wallet } = useGlobalContext()
+  const { wallet, passphraseHash } = useGlobalContext()
   const [isAddressSweepModalOpen, setIsAddressSweepModalOpen] = useState(false)
   const theme = useTheme()
 
@@ -71,16 +71,20 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
   return (
     <>
       <ModalCenteded title="Address options" subtitle={address.getName()} onClose={onClose}>
-        <AddressMetadataForm
-          label={addressLabel}
-          setLabel={setAddressLabel}
-          mainAddressMessage={mainAddressMessage}
-          isMain={isMainAddress}
-          setIsMain={setIsMainAddress}
-          isMainAddressToggleEnabled={isMainAddressToggleEnabled}
-          singleAddress
-        />
-        <HorizontalDivider narrow />
+        {!passphraseHash && (
+          <>
+            <AddressMetadataForm
+              label={addressLabel}
+              setLabel={setAddressLabel}
+              mainAddressMessage={mainAddressMessage}
+              isMain={isMainAddress}
+              setIsMain={setIsMainAddress}
+              isMainAddressToggleEnabled={isMainAddressToggleEnabled}
+              singleAddress
+            />
+            <HorizontalDivider narrow />
+          </>
+        )}
         <KeyValueInput
           label="Sweep address"
           description="Sweep all the unlocked funds of this address to another address."

--- a/src/modals/AddressOptionsModal.tsx
+++ b/src/modals/AddressOptionsModal.tsx
@@ -42,7 +42,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
     color: address?.settings.color ?? getRandomLabelColor()
   })
   const [isMainAddress, setIsMainAddress] = useState(address?.settings.isMain ?? false)
-  const { wallet, passphraseHash } = useGlobalContext()
+  const { wallet, isPassphraseUsed } = useGlobalContext()
   const [isAddressSweepModalOpen, setIsAddressSweepModalOpen] = useState(false)
   const theme = useTheme()
 
@@ -71,7 +71,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
   return (
     <>
       <ModalCenteded title="Address options" subtitle={address.getName()} onClose={onClose}>
-        {!passphraseHash && (
+        {!isPassphraseUsed && (
           <>
             <AddressMetadataForm
               label={addressLabel}

--- a/src/modals/NewAddressModal.tsx
+++ b/src/modals/NewAddressModal.tsx
@@ -123,8 +123,8 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
       )}
       {passphraseHash && singleAddress && (
         <InfoBox contrast noBorders>
-          If you don&apos;t mind which group the address will be in, go ahead and hit that &quot;Generate&quot; button.
-          Otherwise, check out the Advanced options.
+          By default, the address is generated in a random group. You can select the group you want the address to be
+          generated in using the Advanced options.
         </InfoBox>
       )}
       {singleAddress && (

--- a/src/modals/NewAddressModal.tsx
+++ b/src/modals/NewAddressModal.tsx
@@ -123,8 +123,8 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
       )}
       {passphraseHash && singleAddress && (
         <InfoBox contrast noBorders>
-          If you don&apos;t mind in which group the address will be, go ahead and hit that &quot;Generate&quot; button.
-          Otherwise, check out the Advanced options
+          If you don&apos;t mind which group the address will be in, go ahead and hit that &quot;Generate&quot; button.
+          Otherwise, check out the Advanced options.
         </InfoBox>
       )}
       {singleAddress && (

--- a/src/modals/NewAddressModal.tsx
+++ b/src/modals/NewAddressModal.tsx
@@ -37,8 +37,8 @@ interface NewAddressModalProps {
 }
 
 const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps) => {
-  const { wallet, passphraseHash } = useGlobalContext()
-  const [addressLabel, setAddressLabel] = useState({ title: '', color: passphraseHash ? '' : getRandomLabelColor() })
+  const { wallet, isPassphraseUsed } = useGlobalContext()
+  const [addressLabel, setAddressLabel] = useState({ title: '', color: isPassphraseUsed ? '' : getRandomLabelColor() })
   const [isMainAddress, setIsMainAddress] = useState(false)
   const [newAddressData, setNewAddressData] = useState<AddressAndKeys>()
   const [newAddressGroup, setNewAddressGroup] = useState<number>()
@@ -103,7 +103,7 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
 
   return (
     <CenteredModal title={title} onClose={onClose}>
-      {!passphraseHash && (
+      {!isPassphraseUsed && (
         <Section>
           <AddressMetadataForm
             label={addressLabel}
@@ -121,7 +121,7 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
           )}
         </Section>
       )}
-      {passphraseHash && singleAddress && (
+      {isPassphraseUsed && singleAddress && (
         <InfoBox contrast noBorders>
           By default, the address is generated in a random group. You can select the group you want the address to be
           generated in using the Advanced options.

--- a/src/modals/NewAddressModal.tsx
+++ b/src/modals/NewAddressModal.tsx
@@ -41,7 +41,7 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
   const [isMainAddress, setIsMainAddress] = useState(false)
   const [newAddressData, setNewAddressData] = useState<AddressAndKeys>()
   const [newAddressGroup, setNewAddressGroup] = useState<number>()
-  const { wallet } = useGlobalContext()
+  const { wallet, passphraseHash } = useGlobalContext()
   const { addresses, updateAddressSettings, saveNewAddress, mainAddress, generateOneAddressPerGroup } =
     useAddressesContext()
   const currentAddressIndexes = useRef(addresses.map(({ index }) => index))
@@ -103,22 +103,30 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
 
   return (
     <CenteredModal title={title} onClose={onClose}>
-      <Section>
-        <AddressMetadataForm
-          label={addressLabel}
-          setLabel={setAddressLabel}
-          mainAddressMessage={mainAddressMessage}
-          isMain={isMainAddress}
-          setIsMain={setIsMainAddress}
-          isMainAddressToggleEnabled
-          singleAddress={singleAddress}
-        />
-        {!singleAddress && (
-          <InfoBox Icon={Info} contrast noBorders>
-            The group number will be automatically be appended to the addresses’ label.
-          </InfoBox>
-        )}
-      </Section>
+      {!passphraseHash && (
+        <Section>
+          <AddressMetadataForm
+            label={addressLabel}
+            setLabel={setAddressLabel}
+            mainAddressMessage={mainAddressMessage}
+            isMain={isMainAddress}
+            setIsMain={setIsMainAddress}
+            isMainAddressToggleEnabled
+            singleAddress={singleAddress}
+          />
+          {!singleAddress && (
+            <InfoBox Icon={Info} contrast noBorders>
+              The group number will be automatically be appended to the addresses’ label.
+            </InfoBox>
+          )}
+        </Section>
+      )}
+      {passphraseHash && singleAddress && (
+        <InfoBox contrast noBorders>
+          If you don&apos;t mind in which group the address will be, go ahead and hit that &quot;Generate&quot; button.
+          Otherwise, check out the Advanced options
+        </InfoBox>
+      )}
       {singleAddress && (
         <ExpandableSection sectionTitleClosed="Advanced options">
           <Select

--- a/src/modals/NewAddressModal.tsx
+++ b/src/modals/NewAddressModal.tsx
@@ -37,11 +37,11 @@ interface NewAddressModalProps {
 }
 
 const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps) => {
-  const [addressLabel, setAddressLabel] = useState({ title: '', color: getRandomLabelColor() })
+  const { wallet, passphraseHash } = useGlobalContext()
+  const [addressLabel, setAddressLabel] = useState({ title: '', color: passphraseHash ? '' : getRandomLabelColor() })
   const [isMainAddress, setIsMainAddress] = useState(false)
   const [newAddressData, setNewAddressData] = useState<AddressAndKeys>()
   const [newAddressGroup, setNewAddressGroup] = useState<number>()
-  const { wallet, passphraseHash } = useGlobalContext()
   const { addresses, updateAddressSettings, saveNewAddress, mainAddress, generateOneAddressPerGroup } =
     useAddressesContext()
   const currentAddressIndexes = useRef(addresses.map(({ index }) => index))

--- a/src/modals/TransactionDetailsModal.tsx
+++ b/src/modals/TransactionDetailsModal.tsx
@@ -57,7 +57,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
   const isOutgoingTx = amount < 0
   amount = isOutgoingTx ? amount * -1n : amount
   const addressName = address.getLabelName(!isPassphraseUsed)
-  const color = address.settings.color
+  const addressColor = address.settings.color
 
   const handleShowTxInExplorer = () => {
     openInWebBrowser(`${explorerUrl}/#/transactions/${transaction.hash}`)
@@ -77,14 +77,14 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         <HeaderInfo>
           <Direction>{isOutgoingTx ? '↑ Sent' : '↓ Received'}</Direction>
           <FromIn>{isOutgoingTx ? 'from' : 'in'}</FromIn>
-          <AddressBadge color={color} addressName={addressName} truncate />
+          <AddressBadge color={addressColor} addressName={addressName} truncate />
         </HeaderInfo>
         <ActionLink onClick={handleShowTxInExplorer}>↗ Show in explorer</ActionLink>
       </Header>
       <Details>
         <DetailsRow label="From">
           {isOutgoingTx ? (
-            <AddressBadge color={color} addressName={addressName} truncate />
+            <AddressBadge color={addressColor} addressName={addressName} truncate />
           ) : (
             <IOList
               currentAddress={address.hash}
@@ -98,7 +98,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         </DetailsRow>
         <DetailsRow label="To">
           {!isOutgoingTx ? (
-            <AddressBadge color={color} addressName={addressName} />
+            <AddressBadge color={addressColor} addressName={addressName} />
           ) : (
             <IOList
               currentAddress={address.hash}

--- a/src/modals/TransactionDetailsModal.tsx
+++ b/src/modals/TransactionDetailsModal.tsx
@@ -50,12 +50,14 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
     settings: {
       network: { explorerUrl }
     },
-    passphraseHash
+    isPassphraseUsed
   } = useGlobalContext()
   const theme = useTheme()
   let amount = calAmountDelta(transaction, address.hash)
   const isOutgoingTx = amount < 0
   amount = isOutgoingTx ? amount * -1n : amount
+  const addressName = address.getLabelName(!isPassphraseUsed)
+  const color = address.settings.color
 
   const handleShowTxInExplorer = () => {
     openInWebBrowser(`${explorerUrl}/#/transactions/${transaction.hash}`)
@@ -75,14 +77,14 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         <HeaderInfo>
           <Direction>{isOutgoingTx ? '↑ Sent' : '↓ Received'}</Direction>
           <FromIn>{isOutgoingTx ? 'from' : 'in'}</FromIn>
-          <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} truncate />
+          <AddressBadge color={color} addressName={addressName} truncate />
         </HeaderInfo>
         <ActionLink onClick={handleShowTxInExplorer}>↗ Show in explorer</ActionLink>
       </Header>
       <Details>
         <DetailsRow label="From">
           {isOutgoingTx ? (
-            <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} truncate />
+            <AddressBadge color={color} addressName={addressName} truncate />
           ) : (
             <IOList
               currentAddress={address.hash}
@@ -96,7 +98,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         </DetailsRow>
         <DetailsRow label="To">
           {!isOutgoingTx ? (
-            <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} />
+            <AddressBadge color={color} addressName={addressName} />
           ) : (
             <IOList
               currentAddress={address.hash}

--- a/src/modals/TransactionDetailsModal.tsx
+++ b/src/modals/TransactionDetailsModal.tsx
@@ -49,7 +49,8 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
   const {
     settings: {
       network: { explorerUrl }
-    }
+    },
+    passphraseHash
   } = useGlobalContext()
   const theme = useTheme()
   let amount = calAmountDelta(transaction, address.hash)
@@ -74,14 +75,14 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         <HeaderInfo>
           <Direction>{isOutgoingTx ? '↑ Sent' : '↓ Received'}</Direction>
           <FromIn>{isOutgoingTx ? 'from' : 'in'}</FromIn>
-          <AddressBadge color={address.settings.color} addressName={address.getLabelName()} truncate />
+          <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} truncate />
         </HeaderInfo>
         <ActionLink onClick={handleShowTxInExplorer}>↗ Show in explorer</ActionLink>
       </Header>
       <Details>
         <DetailsRow label="From">
           {isOutgoingTx ? (
-            <AddressBadge color={address.settings.color} addressName={address.getLabelName()} truncate />
+            <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} truncate />
           ) : (
             <IOList
               currentAddress={address.hash}
@@ -95,7 +96,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         </DetailsRow>
         <DetailsRow label="To">
           {!isOutgoingTx ? (
-            <AddressBadge color={address.settings.color} addressName={address.getLabelName()} />
+            <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} />
           ) : (
             <IOList
               currentAddress={address.hash}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -135,12 +135,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
           value={credentials.password}
           id="password"
         />
-        <WalletPassphrase
-          value={passphrase}
-          label="Optional passphrase"
-          onChange={onUpdatePassphrase}
-          isValid={passphrase.length > 0}
-        />
+        <WalletPassphrase value={passphrase} onChange={onUpdatePassphrase} />
       </SectionStyled>
       <SectionStyled inList>
         <Button onClick={handleLogin} submit disabled={!credentials.walletName || !credentials.password}>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -110,13 +110,6 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
     login(credentials.accountName, credentials.password, () => navigate('/wallet/overview'), passphrase)
   }
 
-  const onUpdatePassphrase = useCallback(
-    (e: ChangeEvent<HTMLInputElement>): void => {
-      setPassphraseState(e.target.value)
-    },
-    [setPassphraseState]
-  )
-
   return (
     <>
       <SectionStyled inList>
@@ -135,7 +128,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
           value={credentials.password}
           id="password"
         />
-        <WalletPassphrase value={passphrase} onChange={onUpdatePassphrase} />
+        <WalletPassphrase value={passphrase} onChange={setPassphraseState} />
       </SectionStyled>
       <SectionStyled inList>
         <Button onClick={handleLogin} submit disabled={!credentials.walletName || !credentials.password}>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -27,6 +27,7 @@ import Button from '../components/Button'
 import SideBar from '../components/HomePage/SideBar'
 import Input from '../components/Inputs/Input'
 import Select from '../components/Inputs/Select'
+import WalletPassphrase from '../components/Inputs/WalletPassphrase'
 import { FloatingPanel, Section } from '../components/PageComponents/PageContainers'
 import PanelTitle from '../components/PageComponents/PanelTitle'
 import Paragraph from '../components/Paragraph'
@@ -98,6 +99,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
   const [credentials, setCredentials] = useState({ walletName: '', password: '' })
   const { login } = useGlobalContext()
   const navigate = useNavigate()
+  const [passphrase, setPassphraseState] = useState('')
 
   const handleCredentialsChange = useCallback((type: 'walletName' | 'password', value: string) => {
     setCredentials((prev) => ({ ...prev, [type]: value }))
@@ -105,8 +107,15 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
 
   const handleLogin = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault()
-    login(credentials.walletName, credentials.password, () => navigate('/wallet/overview'))
+    login(credentials.accountName, credentials.password, () => navigate('/wallet/overview'), passphrase)
   }
+
+  const onUpdatePassphrase = useCallback(
+    (e: ChangeEvent<HTMLInputElement>): void => {
+      setPassphraseState(e.target.value)
+    },
+    [setPassphraseState]
+  )
 
   return (
     <>
@@ -125,6 +134,12 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
           onChange={(e) => handleCredentialsChange('password', e.target.value)}
           value={credentials.password}
           id="password"
+        />
+        <WalletPassphrase
+          value={passphrase}
+          label="Optional passphrase"
+          onChange={onUpdatePassphrase}
+          isValid={passphrase.length > 0}
         />
       </SectionStyled>
       <SectionStyled inList>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -99,7 +99,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
   const [credentials, setCredentials] = useState({ walletName: '', password: '' })
   const { login } = useGlobalContext()
   const navigate = useNavigate()
-  const [passphrase, setPassphraseState] = useState('')
+  const [passphrase, setPassphrase] = useState('')
 
   const handleCredentialsChange = useCallback((type: 'walletName' | 'password', value: string) => {
     setCredentials((prev) => ({ ...prev, [type]: value }))
@@ -108,6 +108,8 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
   const handleLogin = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault()
     login(credentials.walletName, credentials.password, () => navigate('/wallet/overview'), passphrase)
+
+    if (passphrase) setPassphrase('')
   }
 
   return (
@@ -128,7 +130,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
           value={credentials.password}
           id="password"
         />
-        <WalletPassphrase value={passphrase} onChange={setPassphraseState} />
+        <WalletPassphrase value={passphrase} onChange={setPassphrase} />
       </SectionStyled>
       <SectionStyled>
         <Button onClick={handleLogin} submit disabled={!credentials.walletName || !credentials.password}>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -130,7 +130,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
         />
         <WalletPassphrase value={passphrase} onChange={setPassphraseState} />
       </SectionStyled>
-      <SectionStyled inList>
+      <SectionStyled>
         <Button onClick={handleLogin} submit disabled={!credentials.walletName || !credentials.password}>
           Login
         </Button>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -107,7 +107,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
 
   const handleLogin = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault()
-    login(credentials.accountName, credentials.password, () => navigate('/wallet/overview'), passphrase)
+    login(credentials.walletName, credentials.password, () => navigate('/wallet/overview'), passphrase)
   }
 
   return (

--- a/src/pages/Wallet/AddressDetailsPage.tsx
+++ b/src/pages/Wallet/AddressDetailsPage.tsx
@@ -60,7 +60,7 @@ const AddressDetailsPage = () => {
   const [isAddressOptionsModalOpen, setIsAddressOptionsModalOpen] = useState(false)
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction>()
   const { getAddress, fetchAddressTransactionsNextPage } = useAddressesContext()
-  const { passphraseHash } = useGlobalContext()
+  const { isPassphraseUsed } = useGlobalContext()
   const { addressHash = '' } = useParams<{ addressHash: AddressHash }>()
   const address = getAddress(addressHash)
   const navigate = useNavigate()
@@ -81,7 +81,7 @@ const AddressDetailsPage = () => {
         <Title>
           <ArrowLeftStyled onClick={() => navigate(-1)} />
           <PageH1Styled>
-            Address details {address.settings.isMain && !passphraseHash && <MainAddressLabelStyled />}
+            Address details {address.settings.isMain && !isPassphraseUsed && <MainAddressLabelStyled />}
           </PageH1Styled>
           {address.settings.label && (
             <AddressBadgeStyled color={address.settings.color} addressName={address.getLabelName()} />

--- a/src/pages/Wallet/AddressDetailsPage.tsx
+++ b/src/pages/Wallet/AddressDetailsPage.tsx
@@ -43,6 +43,7 @@ import Tooltip from '../../components/Tooltip'
 import TransactionalInfo from '../../components/TransactionalInfo'
 import Truncate from '../../components/Truncate'
 import { AddressHash, useAddressesContext } from '../../contexts/addresses'
+import { useGlobalContext } from '../../contexts/global'
 import AddressOptionsModal from '../../modals/AddressOptionsModal'
 import TransactionDetailsModal from '../../modals/TransactionDetailsModal'
 
@@ -59,6 +60,7 @@ const AddressDetailsPage = () => {
   const [isAddressOptionsModalOpen, setIsAddressOptionsModalOpen] = useState(false)
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction>()
   const { getAddress, fetchAddressTransactionsNextPage } = useAddressesContext()
+  const { passphraseHash } = useGlobalContext()
   const { addressHash = '' } = useParams<{ addressHash: AddressHash }>()
   const address = getAddress(addressHash)
   const navigate = useNavigate()
@@ -78,7 +80,9 @@ const AddressDetailsPage = () => {
       <PageTitleRow>
         <Title>
           <ArrowLeftStyled onClick={() => navigate(-1)} />
-          <PageH1Styled>Address details {address.settings.isMain && <MainAddressLabelStyled />}</PageH1Styled>
+          <PageH1Styled>
+            Address details {address.settings.isMain && !passphraseHash && <MainAddressLabelStyled />}
+          </PageH1Styled>
           {address.settings.label && (
             <AddressBadgeStyled color={address.settings.color} addressName={address.getLabelName()} />
           )}

--- a/src/pages/Wallet/AddressesPage.tsx
+++ b/src/pages/Wallet/AddressesPage.tsx
@@ -37,6 +37,7 @@ import Spinner from '../../components/Spinner'
 import Table, { TableCell, TableFooter, TableProps, TableRow } from '../../components/Table'
 import Truncate from '../../components/Truncate'
 import { AddressHash, useAddressesContext } from '../../contexts/addresses'
+import { useGlobalContext } from '../../contexts/global'
 import AddressSweepModal from '../../modals/AddressSweepModal'
 import NewAddressModal from '../../modals/NewAddressModal'
 import { sortAddressList } from '../../utils/addresses'
@@ -55,15 +56,24 @@ const tableColumnWidths = addressesTableHeaders.map(({ width }) => width)
 
 const AddressesPage = () => {
   const [isGenerateNewAddressModalOpen, setIsGenerateNewAddressModalOpen] = useState(false)
-  const { addresses } = useAddressesContext()
+  const { addresses, generateOneAddressPerGroup } = useAddressesContext()
   const navigate = useNavigate()
   const [isAdvancedSectionOpen, setIsAdvancedSectionOpen] = useState(false)
   const [isConsolidationModalOpen, setIsConsolidationModalOpen] = useState(false)
   const [isAddressesGenerationModalOpen, setIsAddressesGenerationModalOpen] = useState(false)
+  const { passphraseHash } = useGlobalContext()
   const theme = useTheme()
 
   const navigateToAddressDetailsPage = (addressHash: AddressHash) => {
     navigate(`/wallet/addresses/${addressHash}`)
+  }
+
+  const handleOneAddressPerGroupClick = () => {
+    if (passphraseHash) {
+      generateOneAddressPerGroup()
+    } else {
+      setIsAddressesGenerationModalOpen(true)
+    }
   }
 
   const balanceSummary = addresses.reduce((acc, row) => acc + BigInt(row.details ? row.details.balance : 0), BigInt(0))
@@ -88,7 +98,7 @@ const AddressesPage = () => {
                 {address.settings.isMain ? (
                   <MainAddressWrapper>
                     <Truncate>{address.hash}</Truncate>
-                    <StyledMainAddressLabel />
+                    {!passphraseHash && <StyledMainAddressLabel />}
                   </MainAddressWrapper>
                 ) : (
                   <Truncate>{address.hash}</Truncate>
@@ -146,8 +156,8 @@ const AddressesPage = () => {
             title="Generate one address per group"
             Icon={<HardHat color="#a880ff" strokeWidth={1} size={55} />}
             description="Useful for miners or DeFi use."
-            buttonText="Start"
-            onButtonClick={() => setIsAddressesGenerationModalOpen(true)}
+            buttonText={passphraseHash ? 'Generate' : 'Start'}
+            onButtonClick={handleOneAddressPerGroupClick}
             infoLink="https://wiki.alephium.org/wallet/Desktop-Wallet-Guide#creating-a-mining-wallet-with-4-addresses"
           />
           <OperationBox

--- a/src/pages/Wallet/AddressesPage.tsx
+++ b/src/pages/Wallet/AddressesPage.tsx
@@ -61,7 +61,7 @@ const AddressesPage = () => {
   const [isAdvancedSectionOpen, setIsAdvancedSectionOpen] = useState(false)
   const [isConsolidationModalOpen, setIsConsolidationModalOpen] = useState(false)
   const [isAddressesGenerationModalOpen, setIsAddressesGenerationModalOpen] = useState(false)
-  const { passphraseHash } = useGlobalContext()
+  const { isPassphraseUsed } = useGlobalContext()
   const theme = useTheme()
 
   const navigateToAddressDetailsPage = (addressHash: AddressHash) => {
@@ -69,7 +69,7 @@ const AddressesPage = () => {
   }
 
   const handleOneAddressPerGroupClick = () => {
-    if (passphraseHash) {
+    if (isPassphraseUsed) {
       generateOneAddressPerGroup()
     } else {
       setIsAddressesGenerationModalOpen(true)
@@ -98,7 +98,7 @@ const AddressesPage = () => {
                 {address.settings.isMain ? (
                   <MainAddressWrapper>
                     <Truncate>{address.hash}</Truncate>
-                    {!passphraseHash && <StyledMainAddressLabel />}
+                    {!isPassphraseUsed && <StyledMainAddressLabel />}
                   </MainAddressWrapper>
                 ) : (
                   <Truncate>{address.hash}</Truncate>
@@ -156,7 +156,7 @@ const AddressesPage = () => {
             title="Generate one address per group"
             Icon={<HardHat color="#a880ff" strokeWidth={1} size={55} />}
             description="Useful for miners or DeFi use."
-            buttonText={passphraseHash ? 'Generate' : 'Start'}
+            buttonText={isPassphraseUsed ? 'Generate' : 'Start'}
             onButtonClick={handleOneAddressPerGroupClick}
             infoLink="https://wiki.alephium.org/wallet/Desktop-Wallet-Guide#creating-a-mining-wallet-with-4-addresses"
           />

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -21,7 +21,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Layers, List, Lock, RefreshCw, Send } from 'lucide-react'
-import { ChangeEvent, FC, useCallback, useState } from 'react'
+import { FC, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled, { useTheme } from 'styled-components'
 

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -54,7 +54,7 @@ const WalletLayout: FC = ({ children }) => {
   const { wallet, lockWallet, activeWalletName, login, networkStatus } = useGlobalContext()
   const [isSendModalOpen, setIsSendModalOpen] = useState(false)
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
-  const [passphrase, setPassphraseState] = useState('')
+  const [passphrase, setPassphrase] = useState('')
   const { refreshAddressesData, isLoadingData } = useAddressesContext()
   const navigate = useNavigate()
   const location = useLocation()
@@ -89,7 +89,7 @@ const WalletLayout: FC = ({ children }) => {
       },
       passphrase
     )
-    setPassphraseState('')
+    if (passphrase) setPassphrase('')
   }
 
   if (!wallet) return null
@@ -152,7 +152,7 @@ const WalletLayout: FC = ({ children }) => {
               onCorrectPasswordEntered={onLoginClick}
               walletName={switchToWalletName}
             >
-              <WalletPassphrase value={passphrase} onChange={setPassphraseState} />
+              <WalletPassphrase value={passphrase} onChange={setPassphrase} />
             </PasswordConfirmation>
           </CenteredModal>
         )}

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -92,13 +92,6 @@ const WalletLayout: FC = ({ children }) => {
     setPassphraseState('')
   }
 
-  const onUpdatePassphrase = useCallback(
-    (e: ChangeEvent<HTMLInputElement>): void => {
-      setPassphraseState(e.target.value)
-    },
-    [setPassphraseState]
-  )
-
   if (!wallet) return null
 
   return (
@@ -159,7 +152,7 @@ const WalletLayout: FC = ({ children }) => {
               onCorrectPasswordEntered={onLoginClick}
               walletName={switchToWalletName}
             >
-              <WalletPassphrase value={passphrase} onChange={onUpdatePassphrase} />
+              <WalletPassphrase value={passphrase} onChange={setPassphraseState} />
             </PasswordConfirmation>
           </CenteredModal>
         )}

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -159,12 +159,7 @@ const WalletLayout: FC = ({ children }) => {
               onCorrectPasswordEntered={onLoginClick}
               walletName={switchToWalletName}
             >
-              <WalletPassphrase
-                value={passphrase}
-                label="Optional passphrase"
-                onChange={onUpdatePassphrase}
-                isValid={passphrase.length > 0}
-              />
+              <WalletPassphrase value={passphrase} onChange={onUpdatePassphrase} />
             </PasswordConfirmation>
           </CenteredModal>
         )}

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -21,7 +21,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Layers, List, Lock, RefreshCw, Send } from 'lucide-react'
-import { FC, useState } from 'react'
+import { ChangeEvent, FC, useCallback, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled, { useTheme } from 'styled-components'
 
@@ -30,6 +30,7 @@ import AppHeader from '../../components/AppHeader'
 import Button from '../../components/Button'
 import InfoBox from '../../components/InfoBox'
 import Select from '../../components/Inputs/Select'
+import WalletPassphrase from '../../components/Inputs/WalletPassphrase'
 import PasswordConfirmation from '../../components/PasswordConfirmation'
 import Spinner from '../../components/Spinner'
 import { useAddressesContext } from '../../contexts/addresses'
@@ -53,6 +54,7 @@ const WalletLayout: FC = ({ children }) => {
   const { wallet, lockWallet, activeWalletName, login, networkStatus } = useGlobalContext()
   const [isSendModalOpen, setIsSendModalOpen] = useState(false)
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
+  const [passphrase, setPassphraseState] = useState('')
   const { refreshAddressesData, isLoadingData } = useAddressesContext()
   const navigate = useNavigate()
   const location = useLocation()
@@ -78,11 +80,24 @@ const WalletLayout: FC = ({ children }) => {
 
   const onLoginClick = (password: string) => {
     setIsPasswordModalOpen(false)
-    login(switchToWalletName, password, () => {
-      const nextPageLocation = '/wallet/overview'
-      if (location.pathname !== nextPageLocation) navigate(nextPageLocation)
-    })
+    login(
+      switchToWalletName,
+      password,
+      () => {
+        const nextPageLocation = '/wallet/overview'
+        if (location.pathname !== nextPageLocation) navigate(nextPageLocation)
+      },
+      passphrase
+    )
+    setPassphraseState('')
   }
+
+  const onUpdatePassphrase = useCallback(
+    (e: ChangeEvent<HTMLInputElement>): void => {
+      setPassphraseState(e.target.value)
+    },
+    [setPassphraseState]
+  )
 
   if (!wallet) return null
 
@@ -143,7 +158,14 @@ const WalletLayout: FC = ({ children }) => {
               buttonText="Login"
               onCorrectPasswordEntered={onLoginClick}
               walletName={switchToWalletName}
-            />
+            >
+              <WalletPassphrase
+                value={passphrase}
+                label="Optional passphrase"
+                onChange={onUpdatePassphrase}
+                isValid={passphrase.length > 0}
+              />
+            </PasswordConfirmation>
           </CenteredModal>
         )}
       </AnimatePresence>

--- a/src/pages/WalletManagement/CreateWalletPage.tsx
+++ b/src/pages/WalletManagement/CreateWalletPage.tsx
@@ -22,9 +22,11 @@ import { useState } from 'react'
 import styled from 'styled-components'
 import zxcvbn from 'zxcvbn'
 
+import ActionLink from '../../components/ActionLink'
 import Button from '../../components/Button'
 import InfoBox from '../../components/InfoBox'
 import Input from '../../components/Inputs/Input'
+import WalletPassphrase from '../../components/Inputs/WalletPassphrase'
 import {
   FloatingPanel,
   FooterActionsContainer,
@@ -36,6 +38,7 @@ import Paragraph from '../../components/Paragraph'
 import { useGlobalContext } from '../../contexts/global'
 import { useStepsContext } from '../../contexts/steps'
 import { useWalletContext } from '../../contexts/wallet'
+import { openInWebBrowser } from '../../utils/misc'
 
 const Storage = getStorage()
 
@@ -48,6 +51,7 @@ const CreateWalletPage = ({ isRestoring = false }: { isRestoring?: boolean }) =>
   const [password, setPasswordState] = useState(existingPassword)
   const [passwordError, setPasswordError] = useState('')
   const [passwordCheck, setPasswordCheck] = useState(existingPassword)
+  const [passphrase, setPassphrase] = useState('')
 
   const walletNames = Storage.list()
 
@@ -77,6 +81,10 @@ const CreateWalletPage = ({ isRestoring = false }: { isRestoring?: boolean }) =>
 
     setWalletNameState(walletName)
     setWalletNameError(walletNameError)
+  }
+
+  const onUpdatePassphrase = (e: ChangeEvent<HTMLInputElement>): void => {
+    setPassphrase(e.target.value)
   }
 
   const isNextButtonActive =
@@ -122,6 +130,28 @@ const CreateWalletPage = ({ isRestoring = false }: { isRestoring?: boolean }) =>
             isValid={password.length > 0 && password === passwordCheck}
             disabled={!password || passwordError.length > 0}
           />
+          <InfoBox Icon={AlertTriangle} importance="accent">
+            <div>
+              A wallet passphrase can be set which plausibly denies the funds belong to you. A more detailed explanation
+              about how this protection works can be
+              <ActionLink
+                onClick={() =>
+                  openInWebBrowser(
+                    'https://blog.trezor.io/passphrase-the-ultimate-protection-for-your-accounts-3a311990925b'
+                  )
+                }
+              >
+                &nbsp;found here
+              </ActionLink>
+              .
+            </div>
+            <WalletPassphrase
+              value={passphrase}
+              label="Enter passphrase"
+              onChange={onUpdatePassphrase}
+              isValid={passphrase.length > 0}
+            />
+          </InfoBox>
           <InfoBox
             Icon={AlertTriangle}
             importance="alert"

--- a/src/pages/WalletManagement/CreateWalletPage.tsx
+++ b/src/pages/WalletManagement/CreateWalletPage.tsx
@@ -22,11 +22,9 @@ import { useState } from 'react'
 import styled from 'styled-components'
 import zxcvbn from 'zxcvbn'
 
-import ActionLink from '../../components/ActionLink'
 import Button from '../../components/Button'
 import InfoBox from '../../components/InfoBox'
 import Input from '../../components/Inputs/Input'
-import WalletPassphrase from '../../components/Inputs/WalletPassphrase'
 import {
   FloatingPanel,
   FooterActionsContainer,
@@ -38,7 +36,6 @@ import Paragraph from '../../components/Paragraph'
 import { useGlobalContext } from '../../contexts/global'
 import { useStepsContext } from '../../contexts/steps'
 import { useWalletContext } from '../../contexts/wallet'
-import { openInWebBrowser } from '../../utils/misc'
 
 const Storage = getStorage()
 
@@ -51,7 +48,6 @@ const CreateWalletPage = ({ isRestoring = false }: { isRestoring?: boolean }) =>
   const [password, setPasswordState] = useState(existingPassword)
   const [passwordError, setPasswordError] = useState('')
   const [passwordCheck, setPasswordCheck] = useState(existingPassword)
-  const [passphrase, setPassphrase] = useState('')
 
   const walletNames = Storage.list()
 
@@ -81,10 +77,6 @@ const CreateWalletPage = ({ isRestoring = false }: { isRestoring?: boolean }) =>
 
     setWalletNameState(walletName)
     setWalletNameError(walletNameError)
-  }
-
-  const onUpdatePassphrase = (e: ChangeEvent<HTMLInputElement>): void => {
-    setPassphrase(e.target.value)
   }
 
   const isNextButtonActive =
@@ -130,28 +122,6 @@ const CreateWalletPage = ({ isRestoring = false }: { isRestoring?: boolean }) =>
             isValid={password.length > 0 && password === passwordCheck}
             disabled={!password || passwordError.length > 0}
           />
-          <InfoBox Icon={AlertTriangle} importance="accent">
-            <div>
-              A wallet passphrase can be set which plausibly denies the funds belong to you. A more detailed explanation
-              about how this protection works can be
-              <ActionLink
-                onClick={() =>
-                  openInWebBrowser(
-                    'https://blog.trezor.io/passphrase-the-ultimate-protection-for-your-accounts-3a311990925b'
-                  )
-                }
-              >
-                &nbsp;found here
-              </ActionLink>
-              .
-            </div>
-            <WalletPassphrase
-              value={passphrase}
-              label="Enter passphrase"
-              onChange={onUpdatePassphrase}
-              isValid={passphrase.length > 0}
-            />
-          </InfoBox>
           <InfoBox
             Icon={AlertTriangle}
             importance="alert"

--- a/src/pages/WalletManagement/WalletWordsPage.tsx
+++ b/src/pages/WalletManagement/WalletWordsPage.tsx
@@ -44,10 +44,6 @@ const WalletWordsPage = () => {
     setMnemonic(wallet.mnemonic)
   }, [setMnemonic, setPlainWallet])
 
-  const onGenerate = useCallback(() => {
-    onButtonNext()
-  }, [onButtonNext])
-
   const renderFormatedMnemonic = (mnemonic: string) => {
     return mnemonic.split(' ').map((w, i) => {
       return (
@@ -76,7 +72,7 @@ const WalletWordsPage = () => {
         </WordsContent>
       </PanelContentContainer>
       <FooterActionsContainer apparitionDelay={0.3}>
-        <Button onClick={onGenerate} submit>
+        <Button onClick={onButtonNext} submit>
           {"I've copied the words, continue"}
         </Button>
       </FooterActionsContainer>

--- a/src/pages/WalletManagement/WalletWordsPage.tsx
+++ b/src/pages/WalletManagement/WalletWordsPage.tsx
@@ -18,15 +18,13 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { getWalletFromMnemonic } from '@alephium/sdk'
 import { generateMnemonic } from 'bip39'
-import { AlertTriangle, Edit3 } from 'lucide-react'
-import { ChangeEvent, useCallback, useEffect, useState } from 'react'
+import { Edit3 } from 'lucide-react'
+import { useCallback, useEffect } from 'react'
 import styled from 'styled-components'
 import tinycolor from 'tinycolor2'
 
-import ActionLink from '../../components/ActionLink'
 import Button from '../../components/Button'
 import InfoBox from '../../components/InfoBox'
-import WalletPassphrase from '../../components/Inputs/WalletPassphrase'
 import {
   FloatingPanel,
   FooterActionsContainer,
@@ -36,33 +34,20 @@ import {
 import PanelTitle from '../../components/PageComponents/PanelTitle'
 import { useStepsContext } from '../../contexts/steps'
 import { useWalletContext } from '../../contexts/wallet'
-import { openInWebBrowser } from '../../utils/misc'
 
 const WalletWordsPage = () => {
   const { mnemonic, setPlainWallet, setMnemonic } = useWalletContext()
   const { onButtonBack, onButtonNext } = useStepsContext()
-  const [passphrase, setPassphraseState] = useState('')
 
   useEffect(() => {
     setMnemonic(generateMnemonic(256))
   }, [setMnemonic])
 
   const onGenerate = useCallback(() => {
-    let mnemonicFinal = mnemonic
-    if (passphrase) {
-      mnemonicFinal += ' ' + passphrase
-    }
-    const wallet = getWalletFromMnemonic(mnemonicFinal)
+    const wallet = getWalletFromMnemonic(mnemonic)
     setPlainWallet(wallet)
     onButtonNext()
-  }, [setPlainWallet, onButtonNext, passphrase, mnemonic])
-
-  const onUpdatePassphrase = useCallback(
-    (e: ChangeEvent<HTMLInputElement>): void => {
-      setPassphraseState(e.target.value)
-    },
-    [setPassphraseState]
-  )
+  }, [setPlainWallet, onButtonNext, mnemonic])
 
   const renderFormatedMnemonic = (mnemonic: string) => {
     return mnemonic.split(' ').map((w, i) => {
@@ -89,28 +74,6 @@ const WalletWordsPage = () => {
             Icon={Edit3}
             importance="alert"
           />
-          <InfoBox Icon={AlertTriangle} importance="accent" label="Advanced feature">
-            <div>
-              At this point a wallet passphrase can be set which plausibly denies the funds belong to you. A more
-              detailed explanation about how this protection works can be
-              <ActionLink
-                onClick={() =>
-                  openInWebBrowser(
-                    'https://blog.trezor.io/passphrase-the-ultimate-protection-for-your-accounts-3a311990925b'
-                  )
-                }
-              >
-                &nbsp;found here
-              </ActionLink>
-              . This is also known as the &quot;25th word&quot;.
-            </div>
-            <WalletPassphrase
-              value={passphrase}
-              label="Enter passphrase"
-              onChange={onUpdatePassphrase}
-              isValid={passphrase.length > 0}
-            />
-          </InfoBox>
         </WordsContent>
       </PanelContentContainer>
       <FooterActionsContainer apparitionDelay={0.3}>

--- a/src/pages/WalletManagement/WalletWordsPage.tsx
+++ b/src/pages/WalletManagement/WalletWordsPage.tsx
@@ -16,8 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { getWalletFromMnemonic } from '@alephium/sdk'
-import { generateMnemonic } from 'bip39'
+import { walletGenerate } from '@alephium/sdk'
 import { Edit3 } from 'lucide-react'
 import { useCallback, useEffect } from 'react'
 import styled from 'styled-components'
@@ -40,14 +39,14 @@ const WalletWordsPage = () => {
   const { onButtonBack, onButtonNext } = useStepsContext()
 
   useEffect(() => {
-    setMnemonic(generateMnemonic(256))
-  }, [setMnemonic])
+    const wallet = walletGenerate()
+    setPlainWallet(wallet)
+    setMnemonic(wallet.mnemonic)
+  }, [setMnemonic, setPlainWallet])
 
   const onGenerate = useCallback(() => {
-    const wallet = getWalletFromMnemonic(mnemonic)
-    setPlainWallet(wallet)
     onButtonNext()
-  }, [setPlainWallet, onButtonNext, mnemonic])
+  }, [onButtonNext])
 
   const renderFormatedMnemonic = (mnemonic: string) => {
     return mnemonic.split(' ').map((w, i) => {

--- a/src/pages/WalletManagement/WalletWordsPage.tsx
+++ b/src/pages/WalletManagement/WalletWordsPage.tsx
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { walletGenerate } from '@alephium/sdk'
 import { Edit3 } from 'lucide-react'
-import { useCallback, useEffect } from 'react'
+import { useEffect } from 'react'
 import styled from 'styled-components'
 import tinycolor from 'tinycolor2'
 

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -43,6 +43,10 @@ jest.mock('@alephium/sdk', () => ({
   }
 }))
 
+jest.mock('../utils/migration', () => ({
+  migrateUserData: () => {}
+}))
+
 const walletLockTimeInMinutes = 4
 
 beforeEach(async () => {

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -44,7 +44,7 @@ jest.mock('@alephium/sdk', () => ({
 }))
 
 jest.mock('../utils/migration', () => ({
-  migrateUserData: () => {}
+  migrateUserData: () => ({})
 }))
 
 const walletLockTimeInMinutes = 4

--- a/src/tests/migration.test.ts
+++ b/src/tests/migration.test.ts
@@ -16,11 +16,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { walletGenerate } from '@alephium/sdk'
 import { loadStoredAddressesMetadataOfAccount } from '../utils/addresses'
 import * as migrate from '../utils/migration'
-import { walletGenerate } from '@alephium/sdk'
+import { stringToDoubleSHA256HexString } from '../utils/misc'
 
-// hi
+//
+// ANY CHANGES TO THIS FILE MUST BE REVIEWED BY AT LEAST ONE CORE CONTRIBUTOR
 //
 // Each step should:
 // * Create a wallet
@@ -31,6 +33,83 @@ import { walletGenerate } from '@alephium/sdk'
 // This will mean you need to go into the git history to get the code for
 // address metadata storage (store *and* load) at a period in time.
 //
+
+
+beforeAll(() => {
+  window.localStorage = localStorage
+})
+
+describe('_20220511_074100', () => {
+  const settings = {
+    isMain: true,
+    label: "test",
+    color: "blue"
+  }
+
+  const accounts = new Array(10)
+  .fill({})
+  .map((account, index) =>
+    ({
+      accountName: 'accountName' + index,
+      wallet: walletGenerate(),
+      index,
+      settings
+    })
+  )
+
+  const addressesMetadataLocalStorageKeyPrefix = 'addresses-metadata'
+  const addressesMetadataLocalStorageKeySuffix = 'addresses-metadata'
+
+  // from 1aa10a20e5da393345a0fda220a4a327d709f8ce
+  const _loadStoredAddressesMetadataOfAccount = (accountName: string): AddressMetadata[] => {
+    const data = localStorage.getItem(`${accountName}-${addressesMetadataLocalStorageKeySuffix}`)
+
+    if (data === null) return []
+
+    return JSON.parse(data)
+  }
+  const _storeAddressMetadataOfAccount = (accountName: string, index: number, settings: AddressSettings) => {
+    const addressesMetadata = _loadStoredAddressesMetadataOfAccount(accountName)
+    const existingAddressMetadata = addressesMetadata.find((data: AddressMetadata) => data.index === index)
+
+    if (!existingAddressMetadata) {
+      addressesMetadata.push({
+        index,
+        ...settings
+      })
+    } else {
+      Object.assign(existingAddressMetadata, settings)
+    }
+    localStorage.setItem(`${accountName}-${addressesMetadataLocalStorageKeySuffix}`, JSON.stringify(addressesMetadata))
+  }
+
+
+  // from b8d121ed847cccc0aee841581b432a85ccca3aa5
+  const constructMetadataKey = (walletName: string) => `${addressesMetadataLocalStorageKeyPrefix}-${walletName}`
+  const loadStoredAddressesMetadataOfAccount = (accountName: string): AddressMetadata[] => {
+    const data = localStorage.getItem(constructMetadataKey(accountName))
+
+    if (data === null) return []
+
+    return JSON.parse(data)
+  }
+
+  it('transitions the key names', () => {
+    accounts.forEach(({ accountName, index, settings }) => {
+      // This is necessary because getStorage().list() uses this to list the
+      // wallet account names, which use the key names.
+      localStorage.setItem('wallet-' + accountName, '')
+      _storeAddressMetadataOfAccount(accountName, index, settings)
+    })
+
+    migrate._20220511_074100()
+
+    accounts.forEach(({ accountName, wallet, index, settings }) => {
+      const addresses = loadStoredAddressesMetadataOfAccount(accountName)
+      expect(addresses[0]).toStrictEqual({...settings, index })
+    })
+  })
+})
 
 describe('_20220527_120000', () => {
   const settings = {
@@ -72,7 +151,6 @@ describe('_20220527_120000', () => {
     } else {
       Object.assign(existingAddressMetadata, settings)
     }
-    console.log(`🟠 Storing address index ${index} metadata locally`)
     localStorage.setItem(_constructMetadataKey(accountName), JSON.stringify(addressesMetadata))
   }
 

--- a/src/tests/migration.test.ts
+++ b/src/tests/migration.test.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import * as migrate from '../utils/migration'
+import { walletGenerate } from '@alephium/sdk'
+
+//
+// Each step should:
+// * Create a wallet
+// * Call the storeAddressMetadataOfAccount function (depends on loadStoredAddressesMetadataOfAccount)
+// * Call the migrate step
+// * Verify it worked
+//
+// This will mean you need to go into the git history to get the code for
+// address metadata storage (store *and* load) at a period in time.
+//
+
+test('_20220527_120000', () => {
+  const wallet = walletGenerate()
+  const accountName = 'test'
+
+  const settings = {
+    isMain: true,
+    label: "test",
+    color: "blue"
+  }
+
+  // from b8d121ed847cccc0aee841581b432a85ccca3aa5
+  const _addressesMetadataLocalStorageKeyPrefix = 'addresses-metadata'
+  const _constructMapKey =  (addressHash: AddressHash) => `${addressHash}-${currentNetwork}`
+  const _constructMetadataKey = (walletName: string) => `${addressesMetadataLocalStorageKeyPrefix}-${walletName}`
+  const _loadStoredAddressesMetadataOfAccount = (accountName: string): AddressMetadata[] => {
+    const data = localStorage.getItem(constructMetadataKey(accountName))
+
+    if (data === null) return []
+
+    return JSON.parse(data)
+  }
+  const _storeAddressMetadataOfAccount = (accountName: string, index: number, settings: AddressSettings) => {
+    const addressesMetadata = loadStoredAddressesMetadataOfAccount(accountName)
+    const existingAddressMetadata = addressesMetadata.find((data: AddressMetadata) => data.index === index)
+
+    if (!existingAddressMetadata) {
+      addressesMetadata.push({
+        index,
+        ...settings
+      })
+    } else {
+      Object.assign(existingAddressMetadata, settings)
+    }
+    console.log(`🟠 Storing address index ${index} metadata locally`)
+    localStorage.setItem(constructMetadataKey(accountName), JSON.stringify(addressesMetadata))
+  }
+
+  _storeAddressMetadataOfAccount(accountName, 0, settings)
+  migrate._20220527_120000()
+  const addresses = loadStoredAddressesMetadataOfAccount(wallet.mnemonic, accountName)
+  expect(addresses[0]).ToBe({...settings, index: 0 })
+})

--- a/src/tests/migration.test.ts
+++ b/src/tests/migration.test.ts
@@ -32,7 +32,7 @@ import { walletGenerate } from '@alephium/sdk'
 // address metadata storage (store *and* load) at a period in time.
 //
 
-test('_20220527_120000', () => {
+describe('_20220527_120000', () => {
   const settings = {
     isMain: true,
     label: "test",
@@ -76,21 +76,24 @@ test('_20220527_120000', () => {
     localStorage.setItem(_constructMetadataKey(accountName), JSON.stringify(addressesMetadata))
   }
 
-  accounts.forEach(({ accountName, index, settings }) =>
-    _storeAddressMetadataOfAccount(accountName, index, settings)
-  )
+  it('properly encrypts and decrypts multiple user wallets', () => {
+    accounts.forEach(({ accountName, index, settings }) =>
+      _storeAddressMetadataOfAccount(accountName, index, settings)
+    )
 
-  accounts.forEach(({ accountName, wallet }) =>
-    migrate._20220527_120000(wallet.mnemonic, accountName)
-  )
+    accounts.forEach(({ accountName, wallet }) =>
+      migrate._20220527_120000(wallet.mnemonic, accountName)
+    )
 
-  accounts.forEach(({ accountName, wallet, index, settings }) => {
-    const addresses = loadStoredAddressesMetadataOfAccount(wallet.mnemonic, accountName)
-    expect(addresses[0]).toStrictEqual({...settings, index })
+    accounts.forEach(({ accountName, wallet, index, settings }) => {
+      const addresses = loadStoredAddressesMetadataOfAccount(wallet.mnemonic, accountName)
+      expect(addresses[0]).toStrictEqual({...settings, index })
+    })
   })
 
-  // Make sure it's not the same wallet used for encryption
-  const accountFirst = loadStoredAddressesMetadataOfAccount(accounts[0].wallet.mnemonic, accounts[0].accountName)
-  const accountLast = loadStoredAddressesMetadataOfAccount(accounts[accounts.length - 1].wallet.mnemonic, accounts[accounts.length - 1].accountName)
-  expect(accountFirst).not.toStrictEqual(accountLast)
+  it('does not use the same wallet to encrypt address metadata', () => {
+    const accountFirst = loadStoredAddressesMetadataOfAccount(accounts[0].wallet.mnemonic, accounts[0].accountName)
+    const accountLast = loadStoredAddressesMetadataOfAccount(accounts[accounts.length - 1].wallet.mnemonic, accounts[accounts.length - 1].accountName)
+    expect(accountFirst).not.toStrictEqual(accountLast)
+  })
 })

--- a/src/tests/migration.test.ts
+++ b/src/tests/migration.test.ts
@@ -34,11 +34,6 @@ import { stringToDoubleSHA256HexString } from '../utils/misc'
 // address metadata storage (store *and* load) at a period in time.
 //
 
-
-beforeAll(() => {
-  window.localStorage = localStorage
-})
-
 describe('_20220511_074100', () => {
   const settings = {
     isMain: true,
@@ -170,8 +165,15 @@ describe('_20220527_120000', () => {
   })
 
   it('does not use the same wallet to encrypt address metadata', () => {
-    const accountFirst = loadStoredAddressesMetadataOfAccount(accounts[0].wallet.mnemonic, accounts[0].accountName)
-    const accountLast = loadStoredAddressesMetadataOfAccount(accounts[accounts.length - 1].wallet.mnemonic, accounts[accounts.length - 1].accountName)
+    const accountFirst = loadStoredAddressesMetadataOfAccount({
+      mnemonic: accounts[0].wallet.mnemonic,
+      accountName: accounts[0].accountName
+    })
+
+    const accountLast = loadStoredAddressesMetadataOfAccount({
+      mnemonic: accounts[accounts.length - 1].wallet.mnemonic,
+      accountName: accounts[accounts.length - 1].accountName)
+    })
     expect(accountFirst).not.toStrictEqual(accountLast)
   })
 })

--- a/src/tests/migration.test.ts
+++ b/src/tests/migration.test.ts
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { walletGenerate } from '@alephium/sdk'
 
-import { loadStoredAddressesMetadataOfWallet } from '../utils/addresses'
+import { AddressMetadata, AddressSettings, loadStoredAddressesMetadataOfWallet } from '../utils/addresses'
 import * as migrate from '../utils/migration'
 
 //

--- a/src/tests/migration.test.ts
+++ b/src/tests/migration.test.ts
@@ -145,7 +145,10 @@ describe('_20220527_120000', () => {
     wallets.forEach(({ walletName, wallet }) => migrate._20220527_120000(wallet.mnemonic, walletName))
 
     wallets.forEach(({ walletName, wallet, index, settings }) => {
-      const addresses = loadStoredAddressesMetadataOfWallet(wallet.mnemonic, walletName)
+      const addresses = loadStoredAddressesMetadataOfWallet({
+        mnemonic: wallet.mnemonic,
+        walletName
+      })
       expect(addresses[0]).toStrictEqual({ ...settings, index })
     })
   })

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -43,7 +43,7 @@ export const checkAddressValidity = (address: string) => {
   return match[0] === address && address
 }
 
-const constructMetadataKey = (walletName: string) => `${addressesMetadataLocalStorageKeyPrefix}-${walletName}`
+export const constructMetadataKey = (walletName: string) => `${addressesMetadataLocalStorageKeyPrefix}-${walletName}`
 
 export const loadStoredAddressesMetadataOfAccount = (mnemonic: string, walletName: string): AddressMetadata[] => {
   const json = localStorage.getItem(constructMetadataKey(walletName))

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -42,12 +42,12 @@ export const checkAddressValidity = (address: string) => {
   return match[0] === address && address
 }
 
-export const constructMetadataKey = (accountName: string, passphraseHash?: string) =>
-  `${addressesMetadataLocalStorageKeyPrefix}-${stringToDoubleSHA256HexString(accountName + (passphraseHash ?? ''))}`
+export const constructMetadataKey = (walletName: string, passphraseHash?: string) =>
+  `${addressesMetadataLocalStorageKeyPrefix}-${stringToDoubleSHA256HexString(walletName + (passphraseHash ?? ''))}`
 
 interface AddressMetadataKeyProperties {
   mnemonic: string
-  accountName: string
+  walletName: string
   passphraseHash?: string
 }
 
@@ -108,7 +108,7 @@ export const letSneakyAddressMetadataImpLoose = (timeInterval: number, mnemonic:
   const isGoingToCreateAddressMetadata = Math.floor(Math.random() * timeInterval) + 1 === 1
   if (!isGoingToCreateAddressMetadata) return
 
-  const accountName = Math.random().toString()
+  const walletName = Math.random().toString()
   const passphraseHash = stringToDoubleSHA256HexString(Math.random().toString())
   storeAddressMetadataOfWallet({ mnemonic, walletName, index: 0, settings: { isMain: true }, passphraseHash })
 }

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -21,7 +21,7 @@ import { decrypt, encrypt } from '@alephium/sdk/dist/lib/password-crypto'
 
 import { Address } from '../contexts/addresses'
 import { latestUserDataVersion } from './migration'
-import { stringToDoubleSHA215HexString } from './misc'
+import { stringToDoubleSHA256HexString } from './misc'
 
 const addressesMetadataLocalStorageKeyPrefix = 'addresses-metadata'
 
@@ -112,5 +112,5 @@ export const migrateAddressMetadata = () => {
 export const letSneakyAddressMetadataImpLoose = (timeInterval: number, mnemonic: string) => {
   const isGoingToCreateAddressMetadata = Math.floor(Math.random() * timeInterval) + 1 === 1
   if (!isGoingToCreateAddressMetadata) return
-  storeAddressMetadataOfAccount(mnemonic, stringToDoubleSHA215HexString(Math.random().toString()), 0, { isMain: true })
+  storeAddressMetadataOfAccount(mnemonic, stringToDoubleSHA256HexString(Math.random().toString()), 0, { isMain: true })
 }

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -45,7 +45,7 @@ export const checkAddressValidity = (address: string) => {
 export const constructMetadataKey = (walletName: string, passphraseHash?: string) =>
   `${addressesMetadataLocalStorageKeyPrefix}-${stringToDoubleSHA256HexString(walletName + (passphraseHash ?? ''))}`
 
-interface AddressMetadataKeyProperties {
+interface AddressMetadataKey {
   mnemonic: string
   walletName: string
   passphraseHash?: string
@@ -55,7 +55,7 @@ export const loadStoredAddressesMetadataOfWallet = ({
   mnemonic,
   walletName,
   passphraseHash
-}: AddressMetadataKeyProperties): AddressMetadata[] => {
+}: AddressMetadataKey): AddressMetadata[] => {
   const json = localStorage.getItem(constructMetadataKey(walletName, passphraseHash))
 
   if (json === null) return []
@@ -64,11 +64,9 @@ export const loadStoredAddressesMetadataOfWallet = ({
 }
 
 export const storeAddressMetadataOfWallet = (
-  mnemonic: string,
-  walletName: string,
+  { mnemonic, walletName, passphraseHash }: AddressMetadataKey,
   index: number,
-  settings: AddressSettings,
-  passphraseHash?: string
+  settings: AddressSettings
 ) => {
   const addressesMetadata = loadStoredAddressesMetadataOfWallet({ walletName, mnemonic, passphraseHash })
   const existingAddressMetadata = addressesMetadata.find((data: AddressMetadata) => data.index === index)
@@ -110,5 +108,5 @@ export const letSneakyAddressMetadataImpLoose = (timeInterval: number, mnemonic:
 
   const walletName = Math.random().toString()
   const passphraseHash = stringToDoubleSHA256HexString(Math.random().toString())
-  storeAddressMetadataOfWallet({ mnemonic, walletName, index: 0, settings: { isMain: true }, passphraseHash })
+  storeAddressMetadataOfWallet({ mnemonic, walletName, passphraseHash }, 0, { isMain: true })
 }

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { getStorage } from '@alephium/sdk'
 import { decrypt, encrypt } from '@alephium/sdk/dist/lib/password-crypto'
 
 import { Address } from '../contexts/addresses'
@@ -46,7 +45,17 @@ export const checkAddressValidity = (address: string) => {
 export const constructMetadataKey = (accountName: string, passphraseHash?: string) =>
   `${addressesMetadataLocalStorageKeyPrefix}-${stringToDoubleSHA256HexString(accountName + (passphraseHash ?? ''))}`
 
-export const loadStoredAddressesMetadataOfWallet = (mnemonic: string, walletName: string, passphraseHash?: string): AddressMetadata[] => {
+interface AddressMetadataKeyProperties {
+  mnemonic: string
+  accountName: string
+  passphraseHash?: string
+}
+
+export const loadStoredAddressesMetadataOfWallet = ({
+  mnemonic,
+  walletName,
+  passphraseHash
+}: AddressMetadataKeyProperties): AddressMetadata[] => {
   const json = localStorage.getItem(constructMetadataKey(walletName, passphraseHash))
 
   if (json === null) return []
@@ -98,5 +107,8 @@ export const sortAddressList = (addresses: Address[]): Address[] =>
 export const letSneakyAddressMetadataImpLoose = (timeInterval: number, mnemonic: string) => {
   const isGoingToCreateAddressMetadata = Math.floor(Math.random() * timeInterval) + 1 === 1
   if (!isGoingToCreateAddressMetadata) return
-  storeAddressMetadataOfWallet(mnemonic, Math.random().toString(), Math.random().toString(), 0, { isMain: true })
+
+  const accountName = Math.random().toString()
+  const passphraseHash = stringToDoubleSHA256HexString(Math.random().toString())
+  storeAddressMetadataOfWallet({ mnemonic, walletName, index: 0, settings: { isMain: true }, passphraseHash })
 }

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -60,7 +60,7 @@ export const loadStoredAddressesMetadataOfWallet = ({
 
   if (json === null) return []
   const { encryptedSettings } = JSON.parse(json)
-  return JSON.parse(decrypt(mnemonic, encryptedSettings))
+  return JSON.parse(decrypt(mnemonic + (passphraseHash ?? ''), encryptedSettings))
 }
 
 export const storeAddressMetadataOfWallet = (
@@ -84,10 +84,10 @@ export const storeAddressMetadataOfWallet = (
   console.log(`🟠 Storing address index ${index} metadata locally`)
 
   localStorage.setItem(
-    constructMetadataKey(walletName),
+    constructMetadataKey(walletName, passphraseHash),
     JSON.stringify({
       version: latestUserDataVersion,
-      encryptedSettings: encrypt(mnemonic, JSON.stringify(addressesMetadata))
+      encryptedSettings: encrypt(mnemonic + (passphraseHash ?? ''), JSON.stringify(addressesMetadata))
     })
   )
 }

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -68,6 +68,8 @@ export const storeAddressMetadataOfWallet = (
   index: number,
   settings: AddressSettings
 ) => {
+  if (passphraseHash !== '') return
+
   const addressesMetadata = loadStoredAddressesMetadataOfWallet({ walletName, mnemonic, passphraseHash })
   const existingAddressMetadata = addressesMetadata.find((data: AddressMetadata) => data.index === index)
 
@@ -101,12 +103,3 @@ export const sortAddressList = (addresses: Address[]): Address[] =>
     if (b.settings.isMain) return 1
     return (b.lastUsed ?? 0) - (a.lastUsed ?? 0)
   })
-
-export const letSneakyAddressMetadataImpLoose = (timeInterval: number, mnemonic: string) => {
-  const isGoingToCreateAddressMetadata = Math.floor(Math.random() * timeInterval) + 1 === 1
-  if (!isGoingToCreateAddressMetadata) return
-
-  const walletName = Math.random().toString()
-  const passphraseHash = stringToDoubleSHA256HexString(Math.random().toString())
-  storeAddressMetadataOfWallet({ mnemonic, walletName, passphraseHash }, 0, { isMain: true })
-}

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -70,7 +70,7 @@ export const storeAddressMetadataOfWallet = (
   settings: AddressSettings,
   passphraseHash?: string
 ) => {
-  const addressesMetadata = loadStoredAddressesMetadataOfWallet(walletName, mnemonic, passphraseHash)
+  const addressesMetadata = loadStoredAddressesMetadataOfWallet({ walletName, mnemonic, passphraseHash })
   const existingAddressMetadata = addressesMetadata.find((data: AddressMetadata) => data.index === index)
 
   if (!existingAddressMetadata) {

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -21,6 +21,7 @@ import { decrypt, encrypt } from '@alephium/sdk/dist/lib/password-crypto'
 
 import { Address } from '../contexts/addresses'
 import { latestUserDataVersion } from './migration'
+import { stringToDoubleSHA215HexString } from './misc'
 
 const addressesMetadataLocalStorageKeyPrefix = 'addresses-metadata'
 
@@ -106,4 +107,10 @@ export const migrateAddressMetadata = () => {
       localStorage.removeItem(deprecatedKey)
     }
   }
+}
+
+export const letSneakyAddressMetadataImpLoose = (timeInterval: number, mnemonic: string) => {
+  const isGoingToCreateAddressMetadata = Math.floor(Math.random() * timeInterval) + 1 === 1
+  if (!isGoingToCreateAddressMetadata) return
+  storeAddressMetadataOfAccount(mnemonic, stringToDoubleSHA215HexString(Math.random().toString()), 0, { isMain: true })
 }

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { encrypt } from '@alephium/sdk/dist/lib/password-crypto'
+
+export const latestUserDataVersion = '2022-05-27T12:00:00Z'
+
+//
+// Arguments are essentially dependencies of the migrations.
+// Unfortunately mnemonics are a dependency due to being needed to encrypt address
+// metadata, so migration must absolutely occur after login at the earliest.
+//
+// Future dependencies must be explained as they are added.
+//
+export const migrateUserData = (mnemonic: string) => {
+  console.log('🚚 Migrating user data')
+  _20220527_120000(mnemonic)
+}
+
+const _20220527_120000 = (mnemonic: string) => {
+  const addressMetadata = Object.entries(localStorage).filter(([key, value]) => /^addresses-metadata/.test(key))
+  for (const [key, json] of addressMetadata) {
+    const addressSettingsList = JSON.parse(json)
+
+    //
+    // Means the old format is being used, which is not encrypted.
+    // The data structure can be serialized and then encrypted.
+    // We can also take this opportunity to start versioning our data.
+    //
+    if (Array.isArray(addressSettingsList)) {
+      localStorage.setItem(
+        key,
+        JSON.stringify({
+          version: '2022-05-27T12:00:00Z',
+          encryptedSettings: encrypt(mnemonic, JSON.stringify(addressSettingsList))
+        })
+      )
+    }
+  }
+}

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { encrypt } from '@alephium/sdk/dist/lib/password-crypto'
+
 import { constructMetadataKey } from './addresses'
 
 export const latestUserDataVersion = '2022-05-27T12:00:00Z'
@@ -38,7 +39,11 @@ export const migrateUserData = (mnemonic: string, accountName: string) => {
 export const _20220527_120000 = (mnemonic: string, accountName: string) => {
   const key = constructMetadataKey(accountName)
   const json = localStorage.getItem(key)
+  if (json === null) return
+
   const addressSettingsList = JSON.parse(json)
+
+  alert(JSON.stringify(addressSettingsList))
 
   //
   // Means the old format is being used, which is not encrypted.

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { encrypt } from '@alephium/sdk/dist/lib/password-crypto'
+import { constructMetadataKey } from './addresses'
 
 export const latestUserDataVersion = '2022-05-27T12:00:00Z'
 
@@ -29,29 +30,28 @@ export const latestUserDataVersion = '2022-05-27T12:00:00Z'
 //
 // ANY MODIFICATIONS MUST HAVE TESTS ADDED TO tests/migration.test.ts!
 //
-export const migrateUserData = (mnemonic: string) => {
+export const migrateUserData = (mnemonic: string, accountName: string) => {
   console.log('🚚 Migrating user data')
-  _20220527_120000(mnemonic)
+  _20220527_120000(mnemonic, accountName)
 }
 
-const _20220527_120000 = (mnemonic: string) => {
-  const addressMetadata = Object.entries(localStorage).filter(([key, value]) => /^addresses-metadata/.test(key))
-  for (const [key, json] of addressMetadata) {
-    const addressSettingsList = JSON.parse(json)
+export const _20220527_120000 = (mnemonic: string, accountName: string) => {
+  const key = constructMetadataKey(accountName)
+  const json = localStorage.getItem(key)
+  const addressSettingsList = JSON.parse(json)
 
-    //
-    // Means the old format is being used, which is not encrypted.
-    // The data structure can be serialized and then encrypted.
-    // We can also take this opportunity to start versioning our data.
-    //
-    if (Array.isArray(addressSettingsList)) {
-      localStorage.setItem(
-        key,
-        JSON.stringify({
-          version: '2022-05-27T12:00:00Z',
-          encryptedSettings: encrypt(mnemonic, JSON.stringify(addressSettingsList))
-        })
-      )
-    }
+  //
+  // Means the old format is being used, which is not encrypted.
+  // The data structure can be serialized and then encrypted.
+  // We can also take this opportunity to start versioning our data.
+  //
+  if (Array.isArray(addressSettingsList)) {
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        version: '2022-05-27T12:00:00Z',
+        encryptedSettings: encrypt(mnemonic, JSON.stringify(addressSettingsList))
+      })
+    )
   }
 }

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -27,6 +27,8 @@ export const latestUserDataVersion = '2022-05-27T12:00:00Z'
 //
 // Future dependencies must be explained as they are added.
 //
+// ANY MODIFICATIONS MUST HAVE TESTS ADDED TO tests/migration.test.ts!
+//
 export const migrateUserData = (mnemonic: string) => {
   console.log('🚚 Migrating user data')
   _20220527_120000(mnemonic)

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -19,7 +19,6 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { getStorage } from '@alephium/sdk'
 import { encrypt } from '@alephium/sdk/dist/lib/password-crypto'
 
-import { constructMetadataKey } from './addresses'
 import { stringToDoubleSHA256HexString } from './misc'
 
 export const latestUserDataVersion = '2022-05-27T12:00:00Z'
@@ -75,7 +74,9 @@ export const _20220527_120000 = (mnemonic: string, accountName: string, passphra
   // We can also take this opportunity to start versioning our data.
   //
   if (Array.isArray(addressSettingsList)) {
-    const keyNew = `${addressesMetadataLocalStorageKeyPrefix}-${stringToDoubleSHA256HexString(accountName + (passphraseHash ?? ''))}`
+    const keyNew = `${addressesMetadataLocalStorageKeyPrefix}-${stringToDoubleSHA256HexString(
+      accountName + (passphraseHash ?? '')
+    )}`
     localStorage.setItem(
       keyNew,
       JSON.stringify({

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -41,7 +41,7 @@ export const openInWebBrowser = (url: string) => {
   }
 }
 
-export const stringToDoubleSHA512HexString = (data: string): string => {
+export const stringToDoubleSHA256HexString = (data: string): string => {
   let hash
 
   hash = createHash('sha512')

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -41,7 +41,7 @@ export const openInWebBrowser = (url: string) => {
   }
 }
 
-export const stringToDoubleSHA215HexString = (data: string): string => {
+export const stringToDoubleSHA512HexString = (data: string): string => {
   let hash
 
   hash = createHash('sha512')

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -16,6 +16,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { createHash } from 'crypto'
+
 // ===================== //
 // ==== RUNNING ENV ==== //
 // ===================== //
@@ -37,4 +39,16 @@ export const openInWebBrowser = (url: string) => {
       newWindow.focus()
     }
   }
+}
+
+export const stringToDoubleSHA215HexString = (data: string): string => {
+  let hash
+
+  hash = createHash('sha512')
+  hash.update(data)
+  const first = hash.digest()
+
+  hash = createHash('sha512')
+  hash.update(first)
+  return hash.digest('hex')
 }


### PR DESCRIPTION
I have gone with an approach that does not follow the original proposal. The original proposal does not support BIP39 but instead proposed its own decoy method (which is fine but is not as resilient as BIP39, which is much more preferable by everyone). This PR addresses everyone's concerns :slightly_smiling_face: 

Here is how it works. It fully retains plausible deniability while being user friendly. Note that the passphrase is considered an advanced feature but future iterations will make it less demanding.

* Wallet creation and importing remain the same. desktop-wallet encrypts and saves the wallet (mnemonic, addresses, etc) to disk. **This is the default decoy.**
* Wallet unlocking is different
  * If no passphrase is entered, the decoy is presented.
  * If passphrase is entered, a wallet is derived (based on the mnemonic from the wallet selected plus the passphrase), which may or may not have funds. **Other decoys may be derived here.**

And that's it! It means the advanced users will have to re-discover addresses but at least they retain full plausible deniability. When we tackle address discovery this will no longer be a concern either.

Resolves https://github.com/alephium/desktop-wallet/issues/17