### PR TITLE
Check version once each hour

### DIFF
--- a/src/hooks/useLatestGitHubRelease.ts
+++ b/src/hooks/useLatestGitHubRelease.ts
@@ -16,9 +16,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 
+import { useGlobalContext } from '../contexts/global'
 import { AppData, KEY_APPDATA, toAppData } from '../utils/app-data'
+import { useTimeout } from '../utils/hooks'
 
 const currentVersion = process.env.REACT_APP_VERSION
 const semverRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)?$/
@@ -26,8 +28,10 @@ const semverRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)?$/
 const ONE_HOUR = 1000 * 60 * 60
 
 const useLatestGitHubRelease = () => {
+  const { setSnackbarMessage } = useGlobalContext()
+
   const [newLatestRelease, setNewLatestRelease] = useState('')
-  const { lastVersionCheckedAt }: AppData = JSON.parse(localStorage.getItem(KEY_APPDATA) ?? '{}', toAppData) ?? {}
+  const [timeUntilNextFetch, setTimeUntilNextFetch] = useState(0)
 
   const fetchLatestVersion = async () => {
     const response = await fetch('https://api.github.com/repos/alephium/desktop-wallet/releases/latest')
@@ -39,15 +43,30 @@ const useLatestGitHubRelease = () => {
     }
   }
 
-  useEffect(() => {
-    if (lastVersionCheckedAt !== undefined && Date.now() - lastVersionCheckedAt.getTime() < ONE_HOUR) {
+  const tryFetchLatestVersion = useCallback(async () => {
+    try {
+      await fetchLatestVersion()
+    } catch (e) {
+      console.error(e)
+      setSnackbarMessage({ text: "Couldn't fetch latest wallet version.", type: 'alert' })
+    }
+  }, [setSnackbarMessage])
+
+  useTimeout(async () => {
+    const appData: AppData = JSON.parse(localStorage.getItem(KEY_APPDATA) ?? '{}', toAppData) ?? {}
+    const { lastVersionCheckedAt } = appData
+    const timeSinceLastCheck = (lastVersionCheckedAt !== undefined && Date.now() - lastVersionCheckedAt.getTime()) || 0
+    const nextTimeUntilNextFetch = Math.max(0, ONE_HOUR - timeSinceLastCheck)
+
+    if (timeUntilNextFetch === 0 && nextTimeUntilNextFetch !== 0) {
+      setTimeUntilNextFetch(nextTimeUntilNextFetch)
       return
     }
 
-    localStorage.setItem(KEY_APPDATA, JSON.stringify({ lastVersionCheckedAt: new Date() }))
-
-    fetchLatestVersion()
-  })
+    await tryFetchLatestVersion()
+    localStorage.setItem(KEY_APPDATA, JSON.stringify({ ...appData, lastVersionCheckedAt: new Date() }))
+    setTimeUntilNextFetch(nextTimeUntilNextFetch)
+  }, timeUntilNextFetch)
 
   return newLatestRelease
 }

--- a/src/hooks/useLatestGitHubRelease.ts
+++ b/src/hooks/useLatestGitHubRelease.ts
@@ -58,7 +58,7 @@ const useLatestGitHubRelease = () => {
     const timeSinceLastCheck = (lastVersionCheckedAt !== undefined && Date.now() - lastVersionCheckedAt.getTime()) || 0
     const nextTimeUntilNextFetch = Math.max(0, ONE_HOUR - timeSinceLastCheck)
 
-    if (timeUntilNextFetch === 0 && nextTimeUntilNextFetch !== 0) {
+    if (timeUntilNextFetch === 0 && nextTimeUntilNextFetch !== 0 && lastVersionCheckedAt !== undefined) {
       setTimeUntilNextFetch(nextTimeUntilNextFetch)
       return
     }

--- a/src/hooks/useLatestGitHubRelease.ts
+++ b/src/hooks/useLatestGitHubRelease.ts
@@ -19,7 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { useCallback, useState } from 'react'
 
 import { useGlobalContext } from '../contexts/global'
-import { AppData, KEY_APPDATA, toAppData } from '../utils/app-data'
+import { AppMetaData, KEY_APPMETADATA, toAppMetaData } from '../utils/app-data'
 import { useTimeout } from '../utils/hooks'
 
 const currentVersion = process.env.REACT_APP_VERSION
@@ -53,7 +53,7 @@ const useLatestGitHubRelease = () => {
   }, [setSnackbarMessage])
 
   useTimeout(async () => {
-    const appData: AppData = JSON.parse(localStorage.getItem(KEY_APPDATA) ?? '{}', toAppData) ?? {}
+    const appData: AppMetaData = JSON.parse(localStorage.getItem(KEY_APPMETADATA) ?? '{}', toAppMetaData) ?? {}
     const { lastVersionCheckedAt } = appData
     const timeSinceLastCheck = (lastVersionCheckedAt !== undefined && Date.now() - lastVersionCheckedAt.getTime()) || 0
     const nextTimeUntilNextFetch = Math.max(0, ONE_HOUR - timeSinceLastCheck)
@@ -64,7 +64,7 @@ const useLatestGitHubRelease = () => {
     }
 
     await tryFetchLatestVersion()
-    localStorage.setItem(KEY_APPDATA, JSON.stringify({ ...appData, lastVersionCheckedAt: new Date() }))
+    localStorage.setItem(KEY_APPMETADATA, JSON.stringify({ ...appData, lastVersionCheckedAt: new Date() }))
     setTimeUntilNextFetch(nextTimeUntilNextFetch)
   }, timeUntilNextFetch)
 

--- a/src/utils/app-data.ts
+++ b/src/utils/app-data.ts
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export const KEY_APPDATA = 'alephium/desktop-wallet/appdata'
+
+export interface AppData {
+  lastVersionCheckedAt: Date
+}
+
+export type TypeConstructors = DateConstructor | StringConstructor | NumberConstructor | BooleanConstructor
+
+export const APPDATA_KEYS: Record<string, TypeConstructors> = {
+  lastVersionCheckedAt: Date
+}
+
+export const toAppData = (key: string, value: string): unknown => {
+  if (key === '') return value
+  const TypeConstructor = APPDATA_KEYS[key]
+  return (TypeConstructor && new TypeConstructor(value)) || undefined
+}

--- a/src/utils/app-data.ts
+++ b/src/utils/app-data.ts
@@ -16,20 +16,20 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-export const KEY_APPDATA = 'alephium/desktop-wallet/appdata'
+export const KEY_APPMETADATA = 'alephium/desktop-wallet/appmetadata'
 
-export interface AppData {
+export interface AppMetaData {
   lastVersionCheckedAt: Date
 }
 
 export type TypeConstructors = DateConstructor | StringConstructor | NumberConstructor | BooleanConstructor
 
-export const APPDATA_KEYS: Record<string, TypeConstructors> = {
+export const APPMETADATA_KEYS: Record<string, TypeConstructors> = {
   lastVersionCheckedAt: Date
 }
 
-export const toAppData = (key: string, value: string): unknown => {
+export const toAppMetaData = (key: string, value: string): unknown => {
   if (key === '') return value
-  const TypeConstructor = APPDATA_KEYS[key]
+  const TypeConstructor = APPMETADATA_KEYS[key]
   return (TypeConstructor && new TypeConstructor(value)) || undefined
 }


### PR DESCRIPTION
Resolves https://github.com/alephium/desktop-wallet/issues/257

* On startup, if an hour has passed, check the version, and schedule a timeout for another hour
* If an hour has not passed, schedule a timeout for the time remaining until the next hour
* The version message will only appear once during runtime if there's the same version mismatch (rather than remind the user each hour)
* Thus the version message will appear for _each_ unique version change during the course of the application's lifetime

A new "app data" was created to track this new property, and any future "application lifetime" properties. It's possible there are other properties like this that exist already that should live there but that's out the scope of the issue

This is easier to test if you set `ONE_HOUR` to something like 20 seconds