### PR TITLE
Get the correct network name when switching networks

### DIFF
--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { clone, isEqual, merge } from 'lodash'
+import { clone, merge } from 'lodash'
 
 import { ThemeType } from '../style/themes'
 
@@ -73,9 +73,12 @@ export const networkNames = ['testnet', 'mainnet', 'localhost', 'custom'] as con
 
 export type NetworkName = typeof networkNames[number]
 
+export const isEqualNetwork = (a: Settings['network'], b: Settings['network']): boolean =>
+  a.nodeHost === b.nodeHost && a.explorerUrl === b.explorerUrl && a.explorerApiHost === b.explorerApiHost
+
 export const getNetworkName = (settings: Settings['network']) => {
   return (Object.entries(networkEndpoints).find(([, presetSettings]) => {
-    return isEqual(presetSettings, settings)
+    return isEqualNetwork(presetSettings, settings)
   })?.[0] || 'custom') as NetworkName | 'custom'
 }
 


### PR DESCRIPTION
Resolves https://github.com/alephium/desktop-wallet/issues/253

This was an interesting issue! Initially I was going to use `git bisect` to find where the bug was introduced, but as I was trying to find a good commit, it was evident that there was a data problem at hand. No matter how far back I went, the issue was still present.

After some deeper inspection the cultprit was found: "networkId: 4"

![1655737947](https://user-images.githubusercontent.com/105806603/174635155-27662f8a-324f-451a-b98e-45a6b2cbc297.png)

But how come this causes the network name to be custom? It's because of how network settings are compared to the settings in localStorage. 

```js
export const getNetworkName = (settings: Settings['network']) => {
  return (Object.entries(networkEndpoints).find(([, presetSettings]) => {
    return isEqual(presetSettings, settings)
  })?.[0] || 'custom') as NetworkName | 'custom'
}
```

If the objects are equal (by value / deep comparison), then it returns the key as the name.

Since "networkId: 4" is wedged in that comparison it'll always return "custom".

When was `networkId` introduced? Or should we ask the opposite question: when was it removed? The answer seems to be 10a5631909b3bf42d48464638e57013fb1e11ed3.

![1655739302](https://user-images.githubusercontent.com/105806603/174637061-1579fba1-7e42-4227-adf0-2c48d48ce423.png)

I don't think though this is the source of the problem because it seems so far - it's pre 1.1.0 release. I'm unable though to find any other mention of `networkId`. `git log -S networkId` was used to find that commit and nothing later than that moment mentions it. I quickly checked `js-sdk` and nothing seems relevant there either. Any theories? Did @nop33 and I just so happen to checkout an older version, run it, and forget about it?

This presents a larger problem at hand here: we can't presume the data coming from localStorage is valid or structured as expected.

Creating a Network class with an isEqual method or a function isEqualNetwork (I opted for this) which compares only its properties should adequately fix the problem.
