### PR TITLE
Remove passphrase argument from data migration

### DIFF
--- a/src/components/AddressSummaryCard.tsx
+++ b/src/components/AddressSummaryCard.tsx
@@ -40,7 +40,7 @@ export const addressSummaryCardWidthPx = 100
 
 const AddressSummaryCard = ({ address, clickable, className, index, totalCards }: AddressSummaryCardProps) => {
   const navigate = useNavigate()
-  const { passphraseHash } = useGlobalContext()
+  const { isPassphraseUsed } = useGlobalContext()
 
   const collapsedPosition = !clickable ? (totalCards - index) * -109 + 5 : 0
 
@@ -55,7 +55,7 @@ const AddressSummaryCard = ({ address, clickable, className, index, totalCards }
         <AddressNameSection collapsed={!clickable}>
           <AddressBadgeStyled
             color={address.settings.color}
-            addressName={address.getLabelName(!passphraseHash)}
+            addressName={address.getLabelName(!isPassphraseUsed)}
             truncate
           />
         </AddressNameSection>

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -39,7 +39,7 @@ const AppHeader: FC = ({ children }) => {
   const { scrollY } = useViewportScroll()
   const theme = useTheme()
   const { mainAddress } = useAddressesContext()
-  const { networkStatus, passphraseHash } = useGlobalContext()
+  const { networkStatus, isPassphraseUsed } = useGlobalContext()
   const isOffline = networkStatus === 'offline'
 
   const headerBGColor = useTransform(
@@ -84,7 +84,7 @@ const AppHeader: FC = ({ children }) => {
           IconOff={Eye}
           data-tip="Discreet mode"
         />
-        {mainAddress && !passphraseHash && (
+        {mainAddress && !isPassphraseUsed && (
           <>
             <HeaderDivider />
             <AddressBadge

--- a/src/components/OverviewPage/TransactionList.tsx
+++ b/src/components/OverviewPage/TransactionList.tsx
@@ -44,7 +44,7 @@ interface OverviewPageTransactionListProps {
 const OverviewPageTransactionList = ({ className, onTransactionClick }: OverviewPageTransactionListProps) => {
   const { addresses, fetchAddressTransactionsNextPage, isLoadingData } = useAddressesContext()
   const totalNumberOfTransactions = addresses.map((address) => address.details.txNumber).reduce((a, b) => a + b, 0)
-  const { passphraseHash } = useGlobalContext()
+  const { isPassphraseUsed } = useGlobalContext()
 
   const allConfirmedTxs = addresses
     .map((address) => address.transactions.confirmed.map((tx) => ({ ...tx, address })))
@@ -74,7 +74,7 @@ const OverviewPageTransactionList = ({ className, onTransactionClick }: Overview
             </TableCell>
             <TableCell>{dayjs(timestamp).fromNow()}</TableCell>
             <TableCell>
-              <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} />
+              <AddressBadge color={address.settings.color} addressName={address.getLabelName(!isPassphraseUsed)} />
             </TableCell>
             <TableCell align="end">
               {type === 'transfer' && amount && <TransactionalInfo type="out" prefix="-" content={amount} amount />}
@@ -100,7 +100,7 @@ const OverviewPageTransactionList = ({ className, onTransactionClick }: Overview
               <AddressBadge
                 color={transaction.address.settings.color}
                 truncate
-                addressName={transaction.address.getLabelName(!passphraseHash)}
+                addressName={transaction.address.getLabelName(!isPassphraseUsed)}
               />
             </TableCell>
             <TableCell align="end">

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -163,7 +163,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       network: { nodeHost, explorerApiHost }
     },
     networkStatus,
-    passphraseHash
+    isPassphraseUsed
   } = useGlobalContext()
   const previousWallet = useRef<Wallet | undefined>(wallet)
   const previousNodeApiHost = useRef<string>()
@@ -212,19 +212,20 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const updateAddressSettings = useCallback(
     (address: Address, settings: AddressSettings) => {
       if (!wallet) return
-      storeAddressMetadataOfWallet(
-        {
-          mnemonic: wallet.mnemonic,
-          walletName: activeWalletName,
-          passphraseHash
-        },
-        address.index,
-        settings
-      )
+
+      if (!isPassphraseUsed)
+        storeAddressMetadataOfWallet(
+          {
+            mnemonic: wallet.mnemonic,
+            walletName: activeWalletName
+          },
+          address.index,
+          settings
+        )
       address.settings = settings
       setAddress(address)
     },
-    [setAddress, wallet, activeWalletName, passphraseHash]
+    [wallet, activeWalletName, isPassphraseUsed, setAddress]
   )
 
   const fetchAndStoreAddressesData = useCallback(
@@ -296,19 +297,20 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   const saveNewAddress = useCallback(
     (newAddress: Address) => {
       if (!wallet) return
-      storeAddressMetadataOfWallet(
-        {
-          mnemonic: wallet.mnemonic,
-          walletName: activeWalletName,
-          passphraseHash
-        },
-        newAddress.index,
-        newAddress.settings
-      )
+
+      if (!isPassphraseUsed)
+        storeAddressMetadataOfWallet(
+          {
+            mnemonic: wallet.mnemonic,
+            walletName: activeWalletName
+          },
+          newAddress.index,
+          newAddress.settings
+        )
       setAddress(newAddress)
       fetchAndStoreAddressesData([newAddress])
     },
-    [fetchAndStoreAddressesData, setAddress, wallet, activeWalletName, passphraseHash]
+    [wallet, isPassphraseUsed, activeWalletName, setAddress, fetchAndStoreAddressesData]
   )
 
   const generateOneAddressPerGroup = (labelPrefix?: string, labelColor?: string, skipGroups: number[] = []) => {
@@ -336,11 +338,12 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       console.log('🥇 Initializing current network addresses')
       if (!activeWalletName || !wallet) return
 
-      const addressesMetadata = loadStoredAddressesMetadataOfWallet({
-        mnemonic: wallet.mnemonic,
-        walletName: activeWalletName,
-        passphraseHash
-      })
+      const addressesMetadata = isPassphraseUsed
+        ? []
+        : loadStoredAddressesMetadataOfWallet({
+            mnemonic: wallet.mnemonic,
+            walletName: activeWalletName
+          })
 
       if (addressesMetadata.length === 0) {
         saveNewAddress(

--- a/src/contexts/wallet.tsx
+++ b/src/contexts/wallet.tsx
@@ -28,8 +28,6 @@ export interface WalletContextType {
   setWalletName: (w: string) => void
   password: string
   setPassword: (password: string) => void
-  passphrase: string
-  setPassphrase: (password: string) => void
 }
 
 export const initialWalletContext: WalletContextType = {
@@ -39,9 +37,7 @@ export const initialWalletContext: WalletContextType = {
   setWalletName: () => null,
   password: '',
   setPassword: () => null,
-  setPlainWallet: () => null,
-  passphrase: '',
-  setPassphrase: () => null
+  setPlainWallet: () => null
 }
 
 export const WalletContext = createContext<WalletContextType>(initialWalletContext)
@@ -51,7 +47,6 @@ export const WalletContextProvider: FC = ({ children }) => {
   const [password, setPassword] = useState('')
   const [plainWallet, setPlainWallet] = useState<Wallet>()
   const [mnemonic, setMnemonic] = useState('')
-  const [passphrase, setPassphrase] = useState('')
 
   return (
     <WalletContext.Provider
@@ -63,9 +58,7 @@ export const WalletContextProvider: FC = ({ children }) => {
         mnemonic,
         setMnemonic,
         plainWallet,
-        setPlainWallet,
-        passphrase,
-        setPassphrase
+        setPlainWallet
       }}
     >
       {children}

--- a/src/modals/AddressOptionsModal.tsx
+++ b/src/modals/AddressOptionsModal.tsx
@@ -42,7 +42,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
     color: address?.settings.color ?? getRandomLabelColor()
   })
   const [isMainAddress, setIsMainAddress] = useState(address?.settings.isMain ?? false)
-  const { wallet, passphraseHash } = useGlobalContext()
+  const { wallet, isPassphraseUsed } = useGlobalContext()
   const [isAddressSweepModalOpen, setIsAddressSweepModalOpen] = useState(false)
   const theme = useTheme()
 
@@ -71,7 +71,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
   return (
     <>
       <ModalCenteded title="Address options" subtitle={address.getName()} onClose={onClose}>
-        {!passphraseHash && (
+        {!isPassphraseUsed && (
           <>
             <AddressMetadataForm
               label={addressLabel}

--- a/src/modals/NewAddressModal.tsx
+++ b/src/modals/NewAddressModal.tsx
@@ -37,8 +37,8 @@ interface NewAddressModalProps {
 }
 
 const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps) => {
-  const { wallet, passphraseHash } = useGlobalContext()
-  const [addressLabel, setAddressLabel] = useState({ title: '', color: passphraseHash ? '' : getRandomLabelColor() })
+  const { wallet, isPassphraseUsed } = useGlobalContext()
+  const [addressLabel, setAddressLabel] = useState({ title: '', color: isPassphraseUsed ? '' : getRandomLabelColor() })
   const [isMainAddress, setIsMainAddress] = useState(false)
   const [newAddressData, setNewAddressData] = useState<AddressAndKeys>()
   const [newAddressGroup, setNewAddressGroup] = useState<number>()
@@ -103,7 +103,7 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
 
   return (
     <CenteredModal title={title} onClose={onClose}>
-      {!passphraseHash && (
+      {!isPassphraseUsed && (
         <Section>
           <AddressMetadataForm
             label={addressLabel}
@@ -121,7 +121,7 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
           )}
         </Section>
       )}
-      {passphraseHash && singleAddress && (
+      {isPassphraseUsed && singleAddress && (
         <InfoBox contrast noBorders>
           By default, the address is generated in a random group. You can select the group you want the address to be
           generated in using the Advanced options.

--- a/src/modals/TransactionDetailsModal.tsx
+++ b/src/modals/TransactionDetailsModal.tsx
@@ -57,7 +57,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
   const isOutgoingTx = amount < 0
   amount = isOutgoingTx ? amount * -1n : amount
   const addressName = address.getLabelName(!isPassphraseUsed)
-  const color = address.settings.color
+  const addressColor = address.settings.color
 
   const handleShowTxInExplorer = () => {
     openInWebBrowser(`${explorerUrl}/#/transactions/${transaction.hash}`)
@@ -77,14 +77,14 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         <HeaderInfo>
           <Direction>{isOutgoingTx ? '↑ Sent' : '↓ Received'}</Direction>
           <FromIn>{isOutgoingTx ? 'from' : 'in'}</FromIn>
-          <AddressBadge color={color} addressName={addressName} truncate />
+          <AddressBadge color={addressColor} addressName={addressName} truncate />
         </HeaderInfo>
         <ActionLink onClick={handleShowTxInExplorer}>↗ Show in explorer</ActionLink>
       </Header>
       <Details>
         <DetailsRow label="From">
           {isOutgoingTx ? (
-            <AddressBadge color={color} addressName={addressName} truncate />
+            <AddressBadge color={addressColor} addressName={addressName} truncate />
           ) : (
             <IOList
               currentAddress={address.hash}
@@ -98,7 +98,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         </DetailsRow>
         <DetailsRow label="To">
           {!isOutgoingTx ? (
-            <AddressBadge color={color} addressName={addressName} />
+            <AddressBadge color={addressColor} addressName={addressName} />
           ) : (
             <IOList
               currentAddress={address.hash}

--- a/src/modals/TransactionDetailsModal.tsx
+++ b/src/modals/TransactionDetailsModal.tsx
@@ -50,12 +50,14 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
     settings: {
       network: { explorerUrl }
     },
-    passphraseHash
+    isPassphraseUsed
   } = useGlobalContext()
   const theme = useTheme()
   let amount = calAmountDelta(transaction, address.hash)
   const isOutgoingTx = amount < 0
   amount = isOutgoingTx ? amount * -1n : amount
+  const addressName = address.getLabelName(!isPassphraseUsed)
+  const color = address.settings.color
 
   const handleShowTxInExplorer = () => {
     openInWebBrowser(`${explorerUrl}/#/transactions/${transaction.hash}`)
@@ -75,14 +77,14 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         <HeaderInfo>
           <Direction>{isOutgoingTx ? '↑ Sent' : '↓ Received'}</Direction>
           <FromIn>{isOutgoingTx ? 'from' : 'in'}</FromIn>
-          <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} truncate />
+          <AddressBadge color={color} addressName={addressName} truncate />
         </HeaderInfo>
         <ActionLink onClick={handleShowTxInExplorer}>↗ Show in explorer</ActionLink>
       </Header>
       <Details>
         <DetailsRow label="From">
           {isOutgoingTx ? (
-            <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} truncate />
+            <AddressBadge color={color} addressName={addressName} truncate />
           ) : (
             <IOList
               currentAddress={address.hash}
@@ -96,7 +98,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         </DetailsRow>
         <DetailsRow label="To">
           {!isOutgoingTx ? (
-            <AddressBadge color={address.settings.color} addressName={address.getLabelName(!passphraseHash)} />
+            <AddressBadge color={color} addressName={addressName} />
           ) : (
             <IOList
               currentAddress={address.hash}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -99,7 +99,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
   const [credentials, setCredentials] = useState({ walletName: '', password: '' })
   const { login } = useGlobalContext()
   const navigate = useNavigate()
-  const [passphrase, setPassphraseState] = useState('')
+  const [passphrase, setPassphrase] = useState('')
 
   const handleCredentialsChange = useCallback((type: 'walletName' | 'password', value: string) => {
     setCredentials((prev) => ({ ...prev, [type]: value }))
@@ -108,6 +108,8 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
   const handleLogin = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault()
     login(credentials.walletName, credentials.password, () => navigate('/wallet/overview'), passphrase)
+
+    if (passphrase) setPassphrase('')
   }
 
   return (
@@ -128,7 +130,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
           value={credentials.password}
           id="password"
         />
-        <WalletPassphrase value={passphrase} onChange={setPassphraseState} />
+        <WalletPassphrase value={passphrase} onChange={setPassphrase} />
       </SectionStyled>
       <SectionStyled>
         <Button onClick={handleLogin} submit disabled={!credentials.walletName || !credentials.password}>

--- a/src/pages/Wallet/AddressDetailsPage.tsx
+++ b/src/pages/Wallet/AddressDetailsPage.tsx
@@ -60,7 +60,7 @@ const AddressDetailsPage = () => {
   const [isAddressOptionsModalOpen, setIsAddressOptionsModalOpen] = useState(false)
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction>()
   const { getAddress, fetchAddressTransactionsNextPage } = useAddressesContext()
-  const { passphraseHash } = useGlobalContext()
+  const { isPassphraseUsed } = useGlobalContext()
   const { addressHash = '' } = useParams<{ addressHash: AddressHash }>()
   const address = getAddress(addressHash)
   const navigate = useNavigate()
@@ -81,7 +81,7 @@ const AddressDetailsPage = () => {
         <Title>
           <ArrowLeftStyled onClick={() => navigate(-1)} />
           <PageH1Styled>
-            Address details {address.settings.isMain && !passphraseHash && <MainAddressLabelStyled />}
+            Address details {address.settings.isMain && !isPassphraseUsed && <MainAddressLabelStyled />}
           </PageH1Styled>
           {address.settings.label && (
             <AddressBadgeStyled color={address.settings.color} addressName={address.getLabelName()} />

--- a/src/pages/Wallet/AddressesPage.tsx
+++ b/src/pages/Wallet/AddressesPage.tsx
@@ -61,7 +61,7 @@ const AddressesPage = () => {
   const [isAdvancedSectionOpen, setIsAdvancedSectionOpen] = useState(false)
   const [isConsolidationModalOpen, setIsConsolidationModalOpen] = useState(false)
   const [isAddressesGenerationModalOpen, setIsAddressesGenerationModalOpen] = useState(false)
-  const { passphraseHash } = useGlobalContext()
+  const { isPassphraseUsed } = useGlobalContext()
   const theme = useTheme()
 
   const navigateToAddressDetailsPage = (addressHash: AddressHash) => {
@@ -69,7 +69,7 @@ const AddressesPage = () => {
   }
 
   const handleOneAddressPerGroupClick = () => {
-    if (passphraseHash) {
+    if (isPassphraseUsed) {
       generateOneAddressPerGroup()
     } else {
       setIsAddressesGenerationModalOpen(true)
@@ -98,7 +98,7 @@ const AddressesPage = () => {
                 {address.settings.isMain ? (
                   <MainAddressWrapper>
                     <Truncate>{address.hash}</Truncate>
-                    {!passphraseHash && <StyledMainAddressLabel />}
+                    {!isPassphraseUsed && <StyledMainAddressLabel />}
                   </MainAddressWrapper>
                 ) : (
                   <Truncate>{address.hash}</Truncate>
@@ -156,7 +156,7 @@ const AddressesPage = () => {
             title="Generate one address per group"
             Icon={<HardHat color="#a880ff" strokeWidth={1} size={55} />}
             description="Useful for miners or DeFi use."
-            buttonText={passphraseHash ? 'Generate' : 'Start'}
+            buttonText={isPassphraseUsed ? 'Generate' : 'Start'}
             onButtonClick={handleOneAddressPerGroupClick}
             infoLink="https://wiki.alephium.org/wallet/Desktop-Wallet-Guide#creating-a-mining-wallet-with-4-addresses"
           />

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -54,7 +54,7 @@ const WalletLayout: FC = ({ children }) => {
   const { wallet, lockWallet, activeWalletName, login, networkStatus } = useGlobalContext()
   const [isSendModalOpen, setIsSendModalOpen] = useState(false)
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
-  const [passphrase, setPassphraseState] = useState('')
+  const [passphrase, setPassphrase] = useState('')
   const { refreshAddressesData, isLoadingData } = useAddressesContext()
   const navigate = useNavigate()
   const location = useLocation()
@@ -89,7 +89,7 @@ const WalletLayout: FC = ({ children }) => {
       },
       passphrase
     )
-    setPassphraseState('')
+    if (passphrase) setPassphrase('')
   }
 
   if (!wallet) return null
@@ -152,7 +152,7 @@ const WalletLayout: FC = ({ children }) => {
               onCorrectPasswordEntered={onLoginClick}
               walletName={switchToWalletName}
             >
-              <WalletPassphrase value={passphrase} onChange={setPassphraseState} />
+              <WalletPassphrase value={passphrase} onChange={setPassphrase} />
             </PasswordConfirmation>
           </CenteredModal>
         )}

--- a/src/tests/migration.test.ts
+++ b/src/tests/migration.test.ts
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { walletGenerate } from '@alephium/sdk'
 
-import { loadStoredAddressesMetadataOfWallet } from '../utils/addresses'
+import { AddressMetadata, AddressSettings, loadStoredAddressesMetadataOfWallet } from '../utils/addresses'
 import * as migrate from '../utils/migration'
 
 //


### PR DESCRIPTION
While removing a single arg seemed very trivial, I discovered some more things that had to be done:
- Removed unused passphrase state from `src/contexts/wallet.tsx`
- Removed hashed passphrase from global context and instead store a boolean flag: `isPassphraseUsed`
- Instead of passing the `isPassphraseUsed` arg to the `loadStoredAddressesMetadataOfWallet` and `storeAddressMetadataOfWallet`, just don't call them if passphrase is used
- Keep an optional `isPassphraseUsed` arg in the aforementioned functions for safety
- Rename `accountName` to `walletName` in migration file
- Clean-up component state after logging in

I have tested my changes with the following method:
1. Checked out `master`
2. Created a new wallet, added some metadata (generated a few addresses, added labels and colors)
3. Closed the app
4. Checked out this branch
5. Opened the same wallet to verify the data migration worked. I could still see the addresses/labels ✅ 
6. Opened the same wallet, but with a passphrase. I could not see any addresses/labels ✅ 
7. Repeated the process by swapping steps 5 and 6, just to check ✅ 

@LeeAlephium @mvaivre can you think of another test I could run? Please, feel free to test on your side as well, since this is a very delicate feature and we don't have space for error. Thanks!