### PR TITLE
Don't submit on enter from anywhere in the form

### DIFF
--- a/src/pages/WalletManagement/ImportWordsPage.tsx
+++ b/src/pages/WalletManagement/ImportWordsPage.tsx
@@ -106,7 +106,7 @@ const ImportWordsPage = () => {
         <Button secondary onClick={onButtonBack}>
           Cancel
         </Button>
-        <Button onClick={handleWalletImport} disabled={!isNextButtonActive} submit>
+        <Button onClick={handleWalletImport} disabled={!isNextButtonActive}>
           Continue
         </Button>
       </FooterActionsContainer>


### PR DESCRIPTION
Resolves https://github.com/alephium/desktop-wallet/issues/277

The issue was the form was being submitted no matter where enter was being pressed. The cause of this is a `submit` property set on the `Button`. Removing it removes this behavior, and the button is still able to be navigated to using the keyboard and enter still works when the button has focus