### PR TITLE
Make the application completely keyboard accessible

### DIFF
--- a/locales/en-US/App.json
+++ b/locales/en-US/App.json
@@ -217,7 +217,14 @@
   "welcomeScreenPassphraseMessage": "If you want to use a <1>passphrase</1>, lock your newly created wallet.",
   "I have read and understood the documentation": "I have read and understood the documentation",
   "Use optional passphrase (advanced)": "Use optional passphrase (advanced)",
-  "Optional passphrase": "Optional passphrase",
   "Confirm passphrase": "Confirm passphrase",
-  "Passphrases don't match": "Passphrases don't match"
+  "Passphrases don't match": "Passphrases don't match",
+  "Activate dark mode": "Activate dark mode",
+  "Pick a color": "Pick a color",
+  "Close": "Close",
+  "Tab navigation": "Tab navigation",
+  "Make this your main address": "Make this your main address",
+  "into": "into",
+  "out from": "out from",
+  "Transaction details": "Transaction details"
 }

--- a/locales/en-US/App.json
+++ b/locales/en-US/App.json
@@ -160,6 +160,7 @@
   "Alephium Logo": "Alephium Logo",
   "Alephium": "Alephium",
   "WALLET": "WALLET",
+  "CURRENT WALLET": "CURRENT WALLET",
   "MENU": "MENU",
   "Overview": "Overview",
   "Lock": "Lock",

--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -19,6 +19,8 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled, { css, useTheme } from 'styled-components'
 
+import InputArea from './Inputs/InputArea'
+
 interface ActionButtonProps {
   Icon: LucideIconType
   label: string
@@ -31,7 +33,7 @@ const ActionButton = ({ Icon, label, link, onClick }: ActionButtonProps) => {
   const navigate = useNavigate()
   const location = useLocation()
 
-  const handleClick = () => {
+  const handleInput = () => {
     if (link) {
       navigate(link)
     } else if (onClick) {
@@ -40,7 +42,11 @@ const ActionButton = ({ Icon, label, link, onClick }: ActionButtonProps) => {
   }
 
   return (
-    <ActionButtonContainer onClick={handleClick} isActive={link !== undefined && location.pathname.startsWith(link)}>
+    <ActionButtonContainer
+      aria-label={label}
+      onInput={handleInput}
+      isActive={link !== undefined && location.pathname.startsWith(link)}
+    >
       <ActionContent>
         <ActionIcon>
           <Icon color={theme.font.primary} size={18} />
@@ -50,6 +56,8 @@ const ActionButton = ({ Icon, label, link, onClick }: ActionButtonProps) => {
     </ActionButtonContainer>
   )
 }
+
+export default ActionButton
 
 const ActionLabel = styled.label`
   color: ${({ theme }) => theme.font.secondary};
@@ -74,14 +82,13 @@ const ActionIcon = styled.div`
   transition: all 0.1s ease-out;
 `
 
-const ActionButtonContainer = styled.div<{ isActive: boolean }>`
+const ActionButtonContainer = styled(InputArea)<{ isActive: boolean }>`
   display: flex;
   align-items: stretch;
   width: 100%;
   height: 50px;
 
   &:hover {
-    cursor: pointer;
     ${ActionLabel} {
       color: ${({ theme }) => theme.global.accent};
     }
@@ -103,5 +110,3 @@ const ActionButtonContainer = styled.div<{ isActive: boolean }>`
       }
     `}
 `
-
-export default ActionButton

--- a/src/components/ActionLink.tsx
+++ b/src/components/ActionLink.tsx
@@ -26,9 +26,9 @@ interface ActionLinkProps {
 }
 
 const ActionLink: FC<ActionLinkProps> = ({ className, children, onClick }) => (
-  <a className={className} onClick={onClick}>
+  <button className={className} onClick={onClick}>
     {children}
-  </a>
+  </button>
 )
 
 export default styled(ActionLink)`
@@ -39,5 +39,9 @@ export default styled(ActionLink)`
 
   &:hover {
     color: ${({ theme }) => tinycolor(theme.global.accent).darken(10).toString()};
+  }
+
+  &:focus-visible {
+    text-decoration: underline;
   }
 `

--- a/src/components/AddressMetadataForm.tsx
+++ b/src/components/AddressMetadataForm.tsx
@@ -54,7 +54,12 @@ const AddressMetadataForm = ({
             label={`★ ${t`Main address`}`}
             description={mainAddressMessage}
             InputComponent={
-              <Toggle toggled={isMain} onToggle={() => setIsMain(!isMain)} disabled={!isMainAddressToggleEnabled} />
+              <Toggle
+                toggled={isMain}
+                label={t`Make this your main address`}
+                onToggle={() => setIsMain(!isMain)}
+                disabled={!isMainAddressToggleEnabled}
+              />
             }
           />
         </>

--- a/src/components/AddressSummaryCard.tsx
+++ b/src/components/AddressSummaryCard.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { motion } from 'framer-motion'
+import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 
@@ -25,6 +26,7 @@ import AddressBadge from './AddressBadge'
 import Amount from './Amount'
 import ClipboardButton from './Buttons/ClipboardButton'
 import QRCodeButton from './Buttons/QRCodeButton'
+import InputArea from './Inputs/InputArea'
 
 interface AddressSummaryCardProps {
   address: Address
@@ -41,6 +43,10 @@ const AddressSummaryCard = ({ address, clickable, className, index, totalCards }
   const navigate = useNavigate()
 
   const collapsedPosition = !clickable ? (totalCards - index) * -159 + 5 : 0
+  const onInput = useCallback(
+    () => clickable && navigate(`/wallet/addresses/${address.hash}`),
+    [clickable, address.hash, navigate]
+  )
 
   return (
     <motion.div
@@ -49,14 +55,14 @@ const AddressSummaryCard = ({ address, clickable, className, index, totalCards }
       animate={{ x: collapsedPosition }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
     >
-      <ClickableArea onClick={() => clickable && navigate(`/wallet/addresses/${address.hash}`)} clickable={clickable}>
-        <AddressNameSection collapsed={!clickable}>
+      <InputAreaStyled onInput={onInput} clickable={clickable}>
+        <AddressNameSection collapsed={!clickable} tabIndex={0} role="representation">
           <AddressBadgeStyled address={address} truncate />
         </AddressNameSection>
         <AmountsSection collapsed={!clickable}>
           <AmountHighlighted value={BigInt(address.details.balance)} fadeDecimals />
         </AmountsSection>
-      </ClickableArea>
+      </InputAreaStyled>
       <ButtonsSection collapsed={!clickable}>
         <ClipboardButton textToCopy={address.hash} />
         <QRCodeButton textToEncode={address.hash} />
@@ -140,7 +146,7 @@ const ButtonsSection = styled.div<{ collapsed: boolean }>`
     `}
 `
 
-const ClickableArea = styled.div<{ clickable?: boolean }>`
+const InputAreaStyled = styled(InputArea)<{ clickable?: boolean }>`
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/src/components/Amount.tsx
+++ b/src/components/Amount.tsx
@@ -28,10 +28,19 @@ interface AmountProps {
   fullPrecision?: boolean
   nbOfDecimalsToShow?: number
   color?: string
+  tabIndex?: number
   className?: string
 }
 
-const Amount = ({ value, className, fadeDecimals, fullPrecision = false, color, nbOfDecimalsToShow }: AmountProps) => {
+const Amount = ({
+  value,
+  className,
+  fadeDecimals,
+  fullPrecision = false,
+  color,
+  nbOfDecimalsToShow,
+  tabIndex
+}: AmountProps) => {
   const {
     settings: {
       general: { discreetMode }
@@ -53,7 +62,7 @@ const Amount = ({ value, className, fadeDecimals, fullPrecision = false, color, 
   }
 
   return (
-    <span className={className}>
+    <span className={className} tabIndex={tabIndex ?? -1}>
       {discreetMode ? (
         '•••'
       ) : value !== undefined ? (

--- a/src/components/Buttons/ClipboardButton.tsx
+++ b/src/components/Buttons/ClipboardButton.tsx
@@ -36,7 +36,7 @@ const ClipboardButton = ({ textToCopy, className }: ClipboardButtonProps) => {
   const [hasBeenCopied, setHasBeenCopied] = useState(false)
   const { setSnackbarMessage } = useGlobalContext()
 
-  const handleClick = () => {
+  const handleInput = () => {
     navigator.clipboard
       .writeText(textToCopy)
       .catch((e) => {
@@ -70,7 +70,15 @@ const ClipboardButton = ({ textToCopy, className }: ClipboardButtonProps) => {
   if (!hasBeenCopied) {
     return (
       <div data-tip={t`Copy to clipboard`}>
-        <Clipboard className={`${className} clipboard`} size={15} onClick={handleClick} />
+        <Clipboard
+          className={`${className} clipboard`}
+          size={15}
+          onClick={handleInput}
+          onKeyPress={handleInput}
+          role="button"
+          aria-label={t`Copy to clipboard`}
+          tabIndex={0}
+        />
       </div>
     )
   } else {

--- a/src/components/Buttons/OpenInExplorerButton.tsx
+++ b/src/components/Buttons/OpenInExplorerButton.tsx
@@ -42,7 +42,17 @@ const OpenInExplorerButton = ({ address, className }: OpenInExplorerButtonProps)
     openInWebBrowser(`${explorerUrl}/#/addresses/${address}`)
   }
 
-  return <ExternalLink className={className} data-tip={t`Open in explorer`} size={15} onClick={handleShowInExplorer} />
+  return (
+    <ExternalLink
+      className={className}
+      data-tip={t`Open in explorer`}
+      size={15}
+      onClick={handleShowInExplorer}
+      onKeyPress={handleShowInExplorer}
+      role="link"
+      tabIndex={0}
+    />
+  )
 }
 
 export default styled(OpenInExplorerButton)`

--- a/src/components/DirectionalArrow.tsx
+++ b/src/components/DirectionalArrow.tsx
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { useTranslation } from 'react-i18next'
 import styled, { useTheme } from 'styled-components'
 import tinycolor from 'tinycolor2'
 
@@ -28,15 +29,19 @@ interface DirectionalArrowProps {
 
 const DirectionalArrow = ({ direction }: DirectionalArrowProps) => {
   const theme = useTheme()
+  const { t } = useTranslation('App')
   const isReceiving = direction === 'in'
   const color = {
     circle: isReceiving
-      ? tinycolor(theme.font.secondary).setAlpha(0.11).toString()
-      : tinycolor(theme.global.valid).setAlpha(0.11).toString(),
-    arrow: isReceiving ? theme.font.secondary : theme.global.valid
+      ? tinycolor(theme.global.valid).setAlpha(0.11).toString()
+      : tinycolor(theme.font.secondary).setAlpha(0.11).toString(),
+    arrow: isReceiving ? theme.global.valid : theme.font.secondary
   }
+
+  const ariaLabel = isReceiving ? t`Received` : t`Sent`
+
   return (
-    <Circle color={color.circle}>
+    <Circle color={color.circle} aria-label={ariaLabel}>
       <Arrow direction={direction} color={color.arrow} />
     </Circle>
   )

--- a/src/components/ExpandableSection.tsx
+++ b/src/components/ExpandableSection.tsx
@@ -18,9 +18,10 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { motion } from 'framer-motion'
 import { ChevronDown } from 'lucide-react'
-import { FC, useEffect, useState } from 'react'
+import { FC, useCallback, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 
+import InputArea from './Inputs/InputArea'
 import { Section } from './PageComponents/PageContainers'
 
 interface ExpandableSectionProps {
@@ -46,35 +47,56 @@ const ExpandableSection: FC<ExpandableSectionProps> = ({
   className
 }) => {
   const [isExpanded, setIsExpanded] = useState(open)
+  const [isVisible, setIsVisible] = useState(open)
 
   useEffect(() => {
-    setIsExpanded(open)
+    if (open) {
+      setIsVisible(open)
+      setIsExpanded(open)
+    } else {
+      setIsExpanded(open)
+    }
   }, [open])
 
-  const handleTitleClick = () => {
+  const handleTitleExpansion = () => {
     const newState = !isExpanded
     onOpenChange && onOpenChange(newState)
+    if (newState) {
+      setIsVisible(newState)
+    }
     setIsExpanded(newState)
   }
 
+  const onAnimationComplete = useCallback(() => {
+    setIsVisible(isExpanded)
+  }, [isExpanded])
+
+  const titleText = isExpanded && sectionTitleOpen ? sectionTitleOpen : sectionTitleClosed
+
   return (
     <ExpandableSectionContainer className={className} shrinkWhenOpen={shrinkWhenOpen} isOpen={isExpanded}>
-      <Title onClick={handleTitleClick}>
+      <Title onInput={handleTitleExpansion} aria-expanded={isExpanded}>
         {centered && <LeftDivider />}
         {isCheckbox ? (
-          <input type="checkbox" checked={isExpanded} onChange={() => setIsExpanded(!isExpanded)} />
+          <input type="checkbox" tabIndex={-1} checked={isExpanded} onChange={() => setIsExpanded(!isExpanded)} />
         ) : (
           <Chevron animate={{ rotate: isExpanded ? 180 : 0 }} />
         )}
 
-        <TitleText>{isExpanded && sectionTitleOpen ? sectionTitleOpen : sectionTitleClosed}</TitleText>
+        <TitleText>{titleText}</TitleText>
         <Divider />
       </Title>
-      <ContentWrapper animate={{ height: isExpanded ? 'auto' : 0 }} transition={{ duration: 0.2 }}>
-        <Content>
-          <Section align="stretch">{children}</Section>
-        </Content>
-      </ContentWrapper>
+      {isVisible && (
+        <ContentWrapper
+          onAnimationComplete={onAnimationComplete}
+          animate={{ height: isExpanded ? 'auto' : 0 }}
+          transition={{ duration: 0.2 }}
+        >
+          <Content>
+            <Section align="stretch">{children}</Section>
+          </Content>
+        </ContentWrapper>
+      )}
     </ExpandableSectionContainer>
   )
 }
@@ -95,9 +117,8 @@ const ExpandableSectionContainer = styled.div<{ shrinkWhenOpen: boolean; isOpen?
     `}
 `
 
-const Title = styled.div`
+const Title = styled(InputArea)`
   display: flex;
-  cursor: pointer;
   align-items: center;
   color: ${({ theme }) => theme.global.accent};
 `

--- a/src/components/ExpandableSection.tsx
+++ b/src/components/ExpandableSection.tsx
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { motion } from 'framer-motion'
 import { ChevronDown } from 'lucide-react'
-import { FC, useCallback, useEffect, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import InputArea from './Inputs/InputArea'
@@ -67,10 +67,6 @@ const ExpandableSection: FC<ExpandableSectionProps> = ({
     setIsExpanded(newState)
   }
 
-  const onAnimationComplete = useCallback(() => {
-    setIsVisible(isExpanded)
-  }, [isExpanded])
-
   const titleText = isExpanded && sectionTitleOpen ? sectionTitleOpen : sectionTitleClosed
 
   return (
@@ -88,7 +84,7 @@ const ExpandableSection: FC<ExpandableSectionProps> = ({
       </Title>
       {isVisible && (
         <ContentWrapper
-          onAnimationComplete={onAnimationComplete}
+          onAnimationComplete={() => setIsVisible(isExpanded)}
           animate={{ height: isExpanded ? 'auto' : 0 }}
           transition={{ duration: 0.2 }}
         >

--- a/src/components/HiddenLabel.tsx
+++ b/src/components/HiddenLabel.tsx
@@ -18,7 +18,13 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import styled from 'styled-components'
 
-export default styled(({ text, ...props }) => <div {...props}>{text}</div>)`
+interface HiddenLabelProps {
+  text: string
+}
+
+const HiddenLabel = ({ text, ...props }: HiddenLabelProps) => <div {...props}>{text}</div>
+
+export default styled(HiddenLabel)`
   position: absolute;
   left: -10000px;
   top: auto;

--- a/src/components/HiddenLabel.tsx
+++ b/src/components/HiddenLabel.tsx
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import styled from 'styled-components'
+
+export default styled(({ text, ...props }) => <div {...props}>{text}</div>)`
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+`

--- a/src/components/Inputs/AddressSelect.tsx
+++ b/src/components/Inputs/AddressSelect.tsx
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { AnimatePresence } from 'framer-motion'
 import { MoreVertical } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
@@ -28,10 +28,11 @@ import { sortAddressList } from '../../utils/addresses'
 import AddressBadge from '../AddressBadge'
 import Amount from '../Amount'
 import InfoBox from '../InfoBox'
+import InputArea from '../Inputs/InputArea'
 import { sectionChildrenVariants } from '../PageComponents/PageContainers'
 import Truncate from '../Truncate'
 import { inputDefaultStyle, InputLabel, InputProps } from '.'
-import { MoreIcon, OptionItem, SelectContainer } from './Select'
+import { MoreIcon, SelectContainer } from './Select'
 
 interface AddressSelectProps {
   id: string
@@ -72,6 +73,8 @@ function AddressSelect({
     }
   }, [address, defaultAddress, onAddressChange])
 
+  const onInput = useCallback(() => !disabled && setIsAddressSelectModalOpen(true), [disabled])
+
   return (
     <>
       <AddressSelectContainer
@@ -79,7 +82,7 @@ function AddressSelect({
         animate={canBeAnimated ? (!disabled ? 'shown' : 'disabled') : false}
         onAnimationComplete={() => setCanBeAnimated(true)}
         custom={disabled}
-        onClick={() => !disabled && setIsAddressSelectModalOpen(true)}
+        onInput={onInput}
         disabled={!!disabled}
       >
         <InputLabel inputHasValue={!!address} htmlFor={id}>
@@ -145,7 +148,7 @@ const AddressSelectModal = ({
       <Description>{title}</Description>
       <div>
         {sortAddressList(displayedOptions).map((address) => (
-          <AddressOption key={address.hash} onClick={() => setSelectedAddress(address)}>
+          <AddressOption key={address.hash} onInput={() => setSelectedAddress(address)}>
             <Circle filled={selectedAddress?.hash === address.hash} />
             <AddressBadge address={address} />
             <AmountStyled value={BigInt(address.details.balance)} fadeDecimals />
@@ -212,10 +215,22 @@ const Description = styled.div`
   color: ${({ theme }) => theme.font.secondary};
 `
 
-const AddressOption = styled(OptionItem)`
+const AddressOption = styled(InputArea)`
   display: flex;
   gap: 12px;
   align-items: center;
+
+  padding: var(--spacing-3);
+  background-color: ${({ theme }) => theme.bg.primary};
+  color: inherit;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${({ theme }) => theme.border.primary};
+  }
+
+  &:hover {
+    background-color: ${({ theme }) => theme.bg.secondary};
+  }
 `
 
 const ClickableInput = styled.div<InputProps>`

--- a/src/components/Inputs/AddressSelect.tsx
+++ b/src/components/Inputs/AddressSelect.tsx
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { AnimatePresence } from 'framer-motion'
 import { MoreVertical } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
@@ -73,8 +73,6 @@ function AddressSelect({
     }
   }, [address, defaultAddress, onAddressChange])
 
-  const onInput = useCallback(() => !disabled && setIsAddressSelectModalOpen(true), [disabled])
-
   return (
     <>
       <AddressSelectContainer
@@ -82,7 +80,7 @@ function AddressSelect({
         animate={canBeAnimated ? (!disabled ? 'shown' : 'disabled') : false}
         onAnimationComplete={() => setCanBeAnimated(true)}
         custom={disabled}
-        onInput={onInput}
+        onInput={() => !disabled && setIsAddressSelectModalOpen(true)}
         disabled={!!disabled}
       >
         <InputLabel inputHasValue={!!address} htmlFor={id}>

--- a/src/components/Inputs/AmountInput.tsx
+++ b/src/components/Inputs/AmountInput.tsx
@@ -73,6 +73,7 @@ const AmountInput = ({ className, availableAmount, ...props }: AmountInputProps)
         type="number"
         min={minAmountInAlph}
         max={availableAmountInAlph}
+        aria-label={t`Amount`}
         label={
           <>
             {t`Amount`} (<AlefSymbol color={theme.font.secondary} />)
@@ -83,7 +84,7 @@ const AmountInput = ({ className, availableAmount, ...props }: AmountInputProps)
       />
       {availableAmount && (
         <>
-          <AvailableAmount>
+          <AvailableAmount tabIndex={0}>
             {t`Available`}: <Amount value={BigInt(availableAmount)} nbOfDecimalsToShow={4} />
           </AvailableAmount>
           <ActionLink onClick={onUseMaxAmountClick}>{t`Use max amount`}</ActionLink>

--- a/src/components/Inputs/ColorPicker.tsx
+++ b/src/components/Inputs/ColorPicker.tsx
@@ -20,9 +20,11 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { useState } from 'react'
 import { TwitterPicker } from 'react-color'
 import { useDetectClickOutside } from 'react-detect-click-outside'
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { getRandomLabelColor, labelColorPalette } from '../../utils/colors'
+import InputArea from '../Inputs/InputArea'
 import { inputDefaultStyle, InputProps } from '.'
 
 interface ColorPickerProps {
@@ -31,21 +33,28 @@ interface ColorPickerProps {
 }
 
 const ColorPicker = ({ value, onChange }: ColorPickerProps) => {
+  const { t } = useTranslation('App')
   const color = value?.toString() || getRandomLabelColor()
   const [isPopupOpen, setIsPopupOpen] = useState(false)
   const ref = useDetectClickOutside({ onTriggered: () => setIsPopupOpen(false) })
 
+  const handlePopupOpen = () => setIsPopupOpen(!isPopupOpen)
+  const onChangeComplete = (newColor: { hex: string }) => {
+    onChange(newColor.hex)
+    handlePopupOpen()
+  }
+
   return (
     <ColorPickerContainer ref={ref}>
-      <Input onClick={() => setIsPopupOpen(!isPopupOpen)}>
+      <InputAreaStyled aria-label={t`Pick a color`} onInput={handlePopupOpen}>
         <Circle color={color} />
-      </Input>
+      </InputAreaStyled>
       <AnimatePresence exitBeforeEnter initial={true}>
         {isPopupOpen && (
           <Popup initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
             <TwitterPickerStyled
               color={color}
-              onChangeComplete={(newColor) => onChange(newColor.hex)}
+              onChangeComplete={onChangeComplete}
               colors={labelColorPalette}
               triangle="top-right"
             />
@@ -65,9 +74,8 @@ const ColorPickerContainer = styled.div<InputProps>`
   flex-direction: column;
 `
 
-const Input = styled.div<InputProps>`
+const InputAreaStyled = styled(InputArea)<InputProps>`
   ${({ isValid }) => inputDefaultStyle(isValid)}
-  cursor: pointer;
   position: relative;
   display: inline-flex;
   align-items: center;

--- a/src/components/Inputs/InputArea.tsx
+++ b/src/components/Inputs/InputArea.tsx
@@ -17,14 +17,15 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { motion, MotionProps } from 'framer-motion'
-import { FC } from 'react'
+import { ReactNode } from 'react'
 import styled from 'styled-components'
 
 interface InputAreaProps extends MotionProps {
+  children: ReactNode | ReactNode[]
   onInput?: () => void
 }
 
-const InputArea: FC<InputAreaProps> = ({ onInput, children, ...rest }) => (
+const InputArea = ({ onInput, children, ...rest }: InputAreaProps) => (
   <motion.div role="button" tabIndex={0} onClick={onInput} onKeyPress={onInput} {...rest}>
     {children}
   </motion.div>

--- a/src/components/Inputs/InputArea.tsx
+++ b/src/components/Inputs/InputArea.tsx
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { motion, MotionProps } from 'framer-motion'
+import { FC } from 'react'
+import styled from 'styled-components'
+
+interface InputAreaProps extends MotionProps {
+  onInput?: () => void
+}
+
+const InputArea: FC<InputAreaProps> = ({ onInput, children, ...rest }) => (
+  <motion.div role="button" tabIndex={0} onClick={onInput} onKeyPress={onInput} {...rest}>
+    {children}
+  </motion.div>
+)
+
+export default styled(InputArea)`
+  cursor: pointer;
+`

--- a/src/components/Inputs/Select.tsx
+++ b/src/components/Inputs/Select.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence } from 'framer-motion'
 import { isEqual } from 'lodash'
 import { MoreVertical } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
@@ -25,6 +25,7 @@ import styled, { css } from 'styled-components'
 import { sectionChildrenVariants } from '../PageComponents/PageContainers'
 import Popup from '../Popup'
 import { inputDefaultStyle, InputLabel, InputProps } from './'
+import InputArea from './InputArea'
 
 export interface SelectOption<T> {
   value: T
@@ -70,6 +71,11 @@ function Select<T>({
     [onValueChange, skipEqualityCheck, value]
   )
 
+  const onContainerInput = () => {
+    if (options.length <= 1) return
+    setShowPopup(true)
+  }
+
   useEffect(() => {
     // Controlled component
     if (controlledValue && (!isEqual(controlledValue, value) || skipEqualityCheck)) {
@@ -91,7 +97,7 @@ function Select<T>({
         animate={canBeAnimated ? (!disabled ? 'shown' : 'disabled') : false}
         onAnimationComplete={() => setCanBeAnimated(true)}
         custom={disabled}
-        onClick={() => setShowPopup(true)}
+        onInput={onContainerInput}
       >
         <InputLabel inputHasValue={!!value} htmlFor={id}>
           {label}
@@ -154,11 +160,12 @@ function SelectOptionsPopup<T>({
 
 export default Select
 
-const InputContainer = styled(motion.div)`
+const InputContainer = styled(InputArea)`
   position: relative;
   height: var(--inputHeight);
   width: 100%;
   margin: 16px 0;
+  padding: 0;
 `
 
 export const MoreIcon = styled.div`

--- a/src/components/Inputs/Select.tsx
+++ b/src/components/Inputs/Select.tsx
@@ -157,12 +157,11 @@ function SelectOptionsPopup<T extends OptionValue>({
   onBackgroundClick: () => void
   title?: string
 }) {
-  const handleEvent = (el: HTMLSelectElement) => {
+  const handleEvent = (el: HTMLSelectElement) =>
     handleOptionSelect({
       label: options[el.selectedIndex]?.label,
       value: el.value as T
     })
-  }
 
   const handleOptionSelect = (option: SelectOption<T>) => {
     setValue(option)

--- a/src/components/Inputs/Select.tsx
+++ b/src/components/Inputs/Select.tsx
@@ -172,13 +172,7 @@ function SelectOptionsPopup<T extends OptionValue>({
     <Popup title={title} onBackgroundClick={onBackgroundClick}>
       <OptionSelect autoFocus size={options.length} onKeyPress={(e) => handleEvent(e.currentTarget)}>
         {options.map((o) => (
-          <OptionItem
-            key={o.label}
-            value={o.value}
-            onClick={() => {
-              handleOptionSelect(o)
-            }}
-          >
+          <OptionItem key={o.label} value={o.value} onClick={() => handleOptionSelect(o)}>
             {o.label}
           </OptionItem>
         ))}

--- a/src/components/Inputs/Select.tsx
+++ b/src/components/Inputs/Select.tsx
@@ -19,7 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { AnimatePresence } from 'framer-motion'
 import { isEqual } from 'lodash'
 import { MoreVertical } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { OptionHTMLAttributes, useCallback, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { sectionChildrenVariants } from '../PageComponents/PageContainers'
@@ -27,12 +27,24 @@ import Popup from '../Popup'
 import { inputDefaultStyle, InputLabel, InputProps } from './'
 import InputArea from './InputArea'
 
-export interface SelectOption<T> {
+type Writable<T> = T extends string
+  ? string
+  : T extends number
+  ? number
+  : T extends undefined
+  ? undefined
+  : T extends readonly (infer U)[]
+  ? U
+  : never
+
+export type OptionValue = Writable<OptionHTMLAttributes<HTMLOptionElement>['value']>
+
+export interface SelectOption<T extends OptionValue> {
   value: T
   label: string
 }
 
-interface SelectProps<T> {
+interface SelectProps<T extends OptionValue> {
   label?: string
   disabled?: boolean
   controlledValue?: SelectOption<T>
@@ -45,7 +57,7 @@ interface SelectProps<T> {
   className?: string
 }
 
-function Select<T>({
+function Select<T extends OptionValue>({
   options,
   title,
   label,
@@ -102,11 +114,14 @@ function Select<T>({
         <InputLabel inputHasValue={!!value} htmlFor={id}>
           {label}
         </InputLabel>
-        <MoreIcon>
-          <MoreVertical />
-        </MoreIcon>
+        {options.length > 1 && (
+          <MoreIcon>
+            <MoreVertical />
+          </MoreIcon>
+        )}
         <ClickableInput
           type="text"
+          tabIndex={-1}
           className={className}
           disabled={disabled}
           id={id}
@@ -131,7 +146,7 @@ function Select<T>({
   )
 }
 
-function SelectOptionsPopup<T>({
+function SelectOptionsPopup<T extends OptionValue>({
   options,
   setValue,
   onBackgroundClick,
@@ -142,18 +157,33 @@ function SelectOptionsPopup<T>({
   onBackgroundClick: () => void
   title?: string
 }) {
-  const handleOptionSelect = (value: SelectOption<T>) => {
-    setValue(value)
+  const handleEvent = (el: HTMLSelectElement) => {
+    handleOptionSelect({
+      label: options[el.selectedIndex]?.label,
+      value: el.value as T
+    })
+  }
+
+  const handleOptionSelect = (option: SelectOption<T>) => {
+    setValue(option)
     onBackgroundClick()
   }
 
   return (
     <Popup title={title} onBackgroundClick={onBackgroundClick}>
-      {options.map((o) => (
-        <OptionItem key={o.label} onClick={() => handleOptionSelect(o)}>
-          {o.label}
-        </OptionItem>
-      ))}
+      <OptionSelect autoFocus size={options.length} onKeyPress={(e) => handleEvent(e.currentTarget)}>
+        {options.map((o) => (
+          <OptionItem
+            key={o.label}
+            value={o.value}
+            onClick={() => {
+              handleOptionSelect(o)
+            }}
+          >
+            {o.label}
+          </OptionItem>
+        ))}
+      </OptionSelect>
     </Popup>
   )
 }
@@ -179,10 +209,20 @@ export const SelectContainer = styled(InputContainer)`
   cursor: pointer;
 `
 
-export const OptionItem = styled.div`
+export const OptionSelect = styled.select`
+  width: 100%;
+  overflow-y: auto;
+  border: 0;
+  outline: 0;
+  color: inherit;
+  background: transparent;
+`
+
+export const OptionItem = styled.option`
   padding: var(--spacing-3);
   cursor: pointer;
   background-color: ${({ theme }) => theme.bg.primary};
+  color: inherit;
 
   &:not(:last-child) {
     border-bottom: 1px solid ${({ theme }) => theme.border.primary};

--- a/src/components/Inputs/Toggle.tsx
+++ b/src/components/Inputs/Toggle.tsx
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { motion, Transition } from 'framer-motion'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import styled, { css, useTheme } from 'styled-components'
 
 interface ToggleProps {
@@ -58,11 +58,11 @@ const Toggle = ({ toggled, onToggle, className, disabled, ToggleIcons, handleCol
 
   const transition: Transition = { duration: 0.2, type: 'tween' }
 
-  const handleSwitch = () => {
+  const handleSwitch = useCallback(() => {
     if (!disabled) {
       onToggle(!toggled)
     }
-  }
+  }, [disabled, toggled, onToggle])
 
   const getToggleIconColor = (isActive: boolean) => (isActive ? 'var(--color-white)' : theme.font.tertiary)
 

--- a/src/components/Inputs/Toggle.tsx
+++ b/src/components/Inputs/Toggle.tsx
@@ -26,10 +26,11 @@ interface ToggleProps {
   disabled?: boolean
   ToggleIcons?: [LucideIconType, LucideIconType]
   handleColors?: [string, string]
+  label?: string
   className?: string
 }
 
-const Toggle = ({ toggled, onToggle, className, disabled, ToggleIcons, handleColors }: ToggleProps) => {
+const Toggle = ({ toggled, onToggle, className, disabled, ToggleIcons, handleColors, label }: ToggleProps) => {
   const theme = useTheme()
   const [toggleWidth, setToggleWidth] = useState(0)
   const [ToggleIconRight, ToggleIconLeft] = ToggleIcons ?? [undefined, undefined]
@@ -57,7 +58,7 @@ const Toggle = ({ toggled, onToggle, className, disabled, ToggleIcons, handleCol
 
   const transition: Transition = { duration: 0.2, type: 'tween' }
 
-  const onClick = () => {
+  const handleSwitch = () => {
     if (!disabled) {
       onToggle(!toggled)
     }
@@ -67,8 +68,13 @@ const Toggle = ({ toggled, onToggle, className, disabled, ToggleIcons, handleCol
 
   return (
     <StyledToggle
-      onClick={onClick}
+      onClick={handleSwitch}
+      onKeyPress={handleSwitch}
       className={className}
+      aria-label={label}
+      aria-checked={toggled}
+      role="checkbox"
+      tabIndex={0}
       toggled={toggled}
       variants={toggleBackgroundVariants}
       animate={toggleState}

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -91,6 +91,7 @@ const WalletPassphrase = ({ onPassphraseConfirmed, setIsPassphraseConfirmed, cla
         <label htmlFor="passphrase-consent">{t`I have read and understood the documentation`}</label>
       </ConsentCheckbox>
       <Input
+        id="optional-passphrase"
         value={value}
         label={t`Optional passphrase`}
         type="password"
@@ -98,6 +99,7 @@ const WalletPassphrase = ({ onPassphraseConfirmed, setIsPassphraseConfirmed, cla
         disabled={!isConsentActive}
       />
       <Input
+        id="optional-passphrase-confirm"
         value={confirmValue}
         label={t`Confirm passphrase`}
         type="password"

--- a/src/components/Inputs/index.tsx
+++ b/src/components/Inputs/index.tsx
@@ -118,6 +118,7 @@ InputLabel = styled(InputLabel)`
   color: ${({ theme }) => theme.font.secondary};
   pointer-events: none;
   transform-origin: left;
+  font-size: 12px;
 `
 
 export const InputValidIconContainer = styled(motion.div)`

--- a/src/components/OverviewPage/TransactionList.tsx
+++ b/src/components/OverviewPage/TransactionList.tsx
@@ -50,24 +50,30 @@ const OverviewPageTransactionList = ({ className, onTransactionClick }: Overview
         .slice(0)
         .reverse()
         .map(({ data: tx, address }: BelongingToAddress<PendingTx>) => (
-          <TableRow key={tx.txId} blinking>
+          <TableRow key={tx.txId} blinking role="row" tabIndex={0}>
             {tx.type === 'transfer' && <TransactionalInfo transaction={tx} addressHash={address.hash} />}
           </TableRow>
         ))}
       {allConfirmedTxs.map(({ data: tx, address }: BelongingToAddress<Transaction>) => (
-        <TableRow key={`${tx.hash}-${address.hash}`} onClick={() => onTransactionClick({ ...tx, address })}>
+        <TableRow
+          key={`${tx.hash}-${address.hash}`}
+          role="row"
+          tabIndex={0}
+          onClick={() => onTransactionClick({ ...tx, address })}
+          onKeyPress={() => onTransactionClick({ ...tx, address })}
+        >
           <TransactionalInfo transaction={tx} addressHash={address.hash} />
         </TableRow>
       ))}
       {allConfirmedTxs.length !== totalNumberOfTransactions && (
-        <TableRow>
-          <TableCell align="center">
+        <TableRow role="row">
+          <TableCell align="center" role="gridcell">
             <ActionLink onClick={loadNextTransactionsPage}>{t`Show more`}</ActionLink>
           </TableCell>
         </TableRow>
       )}
       {!isLoadingData && !allPendingTxs.length && !allConfirmedTxs.length && (
-        <TableRow>
+        <TableRow role="row" tabIndex={0}>
           <TableCellPlaceholder align="center">{t`No transactions to display`}</TableCellPlaceholder>
         </TableRow>
       )}

--- a/src/components/PageComponents/PageContainers.tsx
+++ b/src/components/PageComponents/PageContainers.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { motion, MotionStyle, Variants } from 'framer-motion'
+import { HTMLMotionProps, motion, MotionStyle, Variants } from 'framer-motion'
 import { FC } from 'react'
 import styled from 'styled-components'
 
@@ -30,12 +30,11 @@ interface MainPanelProps {
 
 type SectionContentAlignment = 'flex-start' | 'center' | 'stretch'
 
-interface SectionProps {
+interface SectionProps extends HTMLMotionProps<'div'> {
   apparitionDelay?: number
   style?: MotionStyle
   inList?: boolean
   align?: SectionContentAlignment
-  className?: string
 }
 
 const sectionVariants: Variants = {
@@ -67,14 +66,7 @@ export const FloatingPanel: FC<MainPanelProps> = ({ children, ...props }) => (
   </StyledFloatingPanel>
 )
 
-export const Section: FC<SectionProps> = ({
-  children,
-  apparitionDelay,
-  inList,
-  align = 'center',
-  style,
-  className
-}) => (
+export const Section = ({ children, apparitionDelay, inList, align = 'center', style, className }: SectionProps) => (
   <SectionContainer
     variants={sectionVariants}
     initial="hidden"
@@ -90,8 +82,10 @@ export const Section: FC<SectionProps> = ({
   </SectionContainer>
 )
 
-export const BoxContainer: FC = ({ children }) => (
-  <StyledBoxContainer variants={sectionChildrenVariants}>{children}</StyledBoxContainer>
+export const BoxContainer = ({ children, ...props }: HTMLMotionProps<'div'>) => (
+  <StyledBoxContainer variants={sectionChildrenVariants} {...props}>
+    {children}
+  </StyledBoxContainer>
 )
 
 const StyledFloatingPanel = styled(motion.div)<MainPanelProps>`

--- a/src/components/PageComponents/PanelTitle.tsx
+++ b/src/components/PageComponents/PanelTitle.tsx
@@ -43,7 +43,15 @@ const PanelTitle: FC<PanelTitleProps> = ({
 
   return (
     <TitleContainer layoutId={useLayoutId ? 'sectionTitle' : ''} isSticky={isSticky}>
-      {onBackButtonClick && <BackArrow onClick={onBackButtonClick} strokeWidth={3} />}
+      {onBackButtonClick && (
+        <BackArrow
+          onClick={onBackButtonClick}
+          onKeyPress={onBackButtonClick}
+          strokeWidth={3}
+          role="button"
+          tabIndex={0}
+        />
+      )}
       <H1 color={color} smaller={smaller} style={isSticky ? { scale: titleScale, originX: 0 } : {}}>
         {children}
       </H1>

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import { motion } from 'framer-motion'
-import { FC } from 'react'
+import { FC, useCallback, useEffect } from 'react'
 import styled from 'styled-components'
 
 interface PopupProps {
@@ -24,32 +24,43 @@ interface PopupProps {
   title?: string
 }
 
-const Popup: FC<PopupProps> = ({ children, onBackgroundClick, title }) => (
-  <PopupContainer
-    initial={{ opacity: 0 }}
-    animate={{ opacity: 1 }}
-    exit={{ opacity: 0 }}
-    onClick={() => {
-      onBackgroundClick()
-    }}
-  >
-    <PopupContent
-      onClick={(e) => {
-        e.stopPropagation()
-      }}
-      initial={{ y: -10 }}
-      animate={{ y: 0 }}
-      exit={{ y: -10 }}
-    >
-      {title && (
-        <PopupHeader>
-          <h2>{title}</h2>
-        </PopupHeader>
-      )}
-      {children}
-    </PopupContent>
-  </PopupContainer>
-)
+const Popup: FC<PopupProps> = ({ children, onBackgroundClick, title }) => {
+  const handleEscapeKeyPress = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onBackgroundClick()
+      }
+    },
+    [onBackgroundClick]
+  )
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleEscapeKeyPress, false)
+    return () => {
+      document.removeEventListener('keydown', handleEscapeKeyPress, false)
+    }
+  }, [handleEscapeKeyPress, onBackgroundClick])
+
+  return (
+    <PopupContainer initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={onBackgroundClick}>
+      <PopupContent
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
+        initial={{ y: -10 }}
+        animate={{ y: 0 }}
+        exit={{ y: -10 }}
+      >
+        {title && (
+          <PopupHeader>
+            <h2>{title}</h2>
+          </PopupHeader>
+        )}
+        {children}
+      </PopupContent>
+    </PopupContainer>
+  )
+}
 
 export default Popup
 

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -16,15 +16,16 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 import { motion } from 'framer-motion'
-import { FC, useCallback, useEffect } from 'react'
+import { ReactNode, useCallback, useEffect } from 'react'
 import styled from 'styled-components'
 
 interface PopupProps {
   onBackgroundClick: () => void
+  children?: ReactNode | ReactNode[]
   title?: string
 }
 
-const Popup: FC<PopupProps> = ({ children, onBackgroundClick, title }) => {
+const Popup = ({ children, onBackgroundClick, title }: PopupProps) => {
   const handleEscapeKeyPress = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -43,14 +44,7 @@ const Popup: FC<PopupProps> = ({ children, onBackgroundClick, title }) => {
 
   return (
     <PopupContainer initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} onClick={onBackgroundClick}>
-      <PopupContent
-        onClick={(e) => {
-          e.stopPropagation()
-        }}
-        initial={{ y: -10 }}
-        animate={{ y: 0 }}
-        exit={{ y: -10 }}
-      >
+      <PopupContent onClick={(e) => e.stopPropagation()} initial={{ y: -10 }} animate={{ y: 0 }} exit={{ y: -10 }}>
         {title && (
           <PopupHeader>
             <h2>{title}</h2>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { motion } from 'framer-motion'
+import { HTMLAttributes, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -45,13 +46,13 @@ const TabBar = ({ tabItems, onTabChange, activeTab }: TabBarProps) => {
         <TabBarContent>
           {tabItems.map((i) => (
             <TabContainer key={i.value}>
-              <Tab
+              <TabStyled
                 onClick={() => onTabChange(i)}
                 onKeyPress={() => onTabChange(i)}
                 isActive={activeTab.value === i.value}
               >
                 {i.label}
-              </Tab>
+              </TabStyled>
             </TabContainer>
           ))}
         </TabBarContent>
@@ -100,11 +101,18 @@ const TabSelector = styled(motion.div)`
   z-index: -1;
 `
 
-const Tab = styled(({ isActive, onClick, onKeyPress, children, className }) => (
-  <div className={className} onClick={onClick} onKeyPress={onKeyPress} role="tab" tabIndex={0} aria-selected={isActive}>
+interface TabProps extends HTMLAttributes<HTMLDivElement> {
+  isActive: boolean
+  children: ReactNode | ReactNode[]
+}
+
+const Tab = ({ isActive, children, ...props }: TabProps) => (
+  <div {...props} role="tab" tabIndex={0} aria-selected={isActive}>
     {children}
   </div>
-))`
+)
+
+const TabStyled = styled(Tab)`
   flex: 1;
   text-align: center;
   padding: 8px;

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { motion } from 'framer-motion'
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 export interface TabItem {
@@ -30,26 +31,34 @@ interface TabBarProps {
   activeTab: TabItem
 }
 
-const TabBar = ({ tabItems, onTabChange, activeTab }: TabBarProps) => (
-  <Wrapper>
-    <TabBarContainer>
-      <TabSelector
-        animate={{ x: `${tabItems.findIndex((t) => t.value === activeTab.value) * 100}%` }}
-        transition={{ duration: 0.2 }}
-        style={{ width: `${100 / tabItems.length}%` }}
-      />
-      <TabBarContent>
-        {tabItems.map((i) => (
-          <TabContainer key={i.value}>
-            <Tab onClick={() => onTabChange(i)} isActive={activeTab.value === i.value}>
-              {i.label}
-            </Tab>
-          </TabContainer>
-        ))}
-      </TabBarContent>
-    </TabBarContainer>
-  </Wrapper>
-)
+const TabBar = ({ tabItems, onTabChange, activeTab }: TabBarProps) => {
+  const { t } = useTranslation('App')
+
+  return (
+    <Wrapper>
+      <TabBarContainer role="tablist" aria-label={t('Tab navigation')}>
+        <TabSelector
+          animate={{ x: `${tabItems.findIndex((t) => t.value === activeTab.value) * 100}%` }}
+          transition={{ duration: 0.2 }}
+          style={{ width: `${100 / tabItems.length}%` }}
+        />
+        <TabBarContent>
+          {tabItems.map((i) => (
+            <TabContainer key={i.value}>
+              <Tab
+                onClick={() => onTabChange(i)}
+                onKeyPress={() => onTabChange(i)}
+                isActive={activeTab.value === i.value}
+              >
+                {i.label}
+              </Tab>
+            </TabContainer>
+          ))}
+        </TabBarContent>
+      </TabBarContainer>
+    </Wrapper>
+  )
+}
 
 export default TabBar
 
@@ -81,7 +90,21 @@ const TabContainer = styled.div`
   display: flex;
 `
 
-const Tab = styled.div<{ isActive: boolean }>`
+const TabSelector = styled(motion.div)`
+  position: absolute;
+  bottom: 0;
+  height: 2px;
+  border-radius: var(--radius);
+  flex: 1;
+  background-color: ${({ theme }) => theme.global.accent};
+  z-index: -1;
+`
+
+const Tab = styled(({ isActive, onClick, onKeyPress, children, className }) => (
+  <div className={className} onClick={onClick} onKeyPress={onKeyPress} role="tab" tabIndex={0} aria-selected={isActive}>
+    {children}
+  </div>
+))`
   flex: 1;
   text-align: center;
   padding: 8px;
@@ -93,14 +116,4 @@ const Tab = styled.div<{ isActive: boolean }>`
   &:hover {
     color: ${({ theme }) => theme.font.primary};
   }
-`
-
-const TabSelector = styled(motion.div)`
-  position: absolute;
-  bottom: 0;
-  height: 2px;
-  border-radius: var(--radius);
-  flex: 1;
-  background-color: ${({ theme }) => theme.global.accent};
-  z-index: -1;
 `

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -40,11 +40,11 @@ interface TableCellProps {
 
 const Table: FC<TableProps> = ({ className, children, headers, isLoading }) => (
   <ScrollableWrapper>
-    <div className={classNames(className, { 'skeleton-loader': isLoading })}>
+    <div role="table" tabIndex={0} className={classNames(className, { 'skeleton-loader': isLoading })}>
       {headers && headers.length > 0 && (
-        <TableHeaderRow columnWidths={headers.map(({ width }) => width)}>
+        <TableHeaderRow role="rowheader" tabIndex={0} columnWidths={headers.map(({ width }) => width)}>
           {headers.map(({ title, align }) => (
-            <TableHeaderCell key={title} align={align}>
+            <TableHeaderCell role="rowheader" key={title} align={align}>
               {title}
             </TableHeaderCell>
           ))}

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -18,6 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { Moon, Sun } from 'lucide-react'
 import { FC, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { useGlobalContext } from '../contexts/global'
 import { ThemeType } from '../style/themes'
@@ -28,6 +29,8 @@ interface ThemeSwitcherProps {
 }
 
 const ThemeSwitcher: FC<ThemeSwitcherProps> = ({ className }) => {
+  const { t } = useTranslation('App')
+
   const {
     settings: {
       general: { theme: currentTheme }
@@ -46,6 +49,7 @@ const ThemeSwitcher: FC<ThemeSwitcherProps> = ({ className }) => {
 
   return (
     <Toggle
+      label={t`Activate dark mode`}
       ToggleIcons={[Sun, Moon]}
       handleColors={['var(--color-orange)', 'var(--color-purple)']}
       toggled={currentTheme === 'dark'}

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { calAmountDelta } from '@alephium/sdk'
+import { calAmountDelta, formatAmountForDisplay } from '@alephium/sdk'
 import { Output, Transaction } from '@alephium/sdk/api/explorer'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
@@ -28,6 +28,7 @@ import AddressBadge from './AddressBadge'
 import Amount from './Amount'
 import Badge from './Badge'
 import DirectionalArrow from './DirectionalArrow'
+import HiddenLabel from './HiddenLabel'
 import IOList from './IOList'
 import TimeSince from './TimeSince'
 import Token from './Token'
@@ -71,6 +72,9 @@ const TransactionalInfo = ({ transaction: tx, addressHash, className, hideLabel 
     throw new Error('Could not determine transaction type, all transactions should have a type')
   }
 
+  const amountFormatted = formatAmountForDisplay(BigInt(amount ?? 0))
+  const intoOrOutFromText = type === 'out' ? t`out from` : t`into`
+
   return (
     <div className={className}>
       <CellAmountTokenTime>
@@ -78,6 +82,7 @@ const TransactionalInfo = ({ transaction: tx, addressHash, className, hideLabel 
           <DirectionalArrow direction={type} />
         </CellArrow>
         <TokenTimeInner>
+          <HiddenLabel text={amountFormatted} />
           <TokenStyled type={token} />
           <TimeSince timestamp={timestamp} faded />
         </TokenTimeInner>
@@ -86,6 +91,7 @@ const TransactionalInfo = ({ transaction: tx, addressHash, className, hideLabel 
         <CellAddress>
           {!hideLabel && (
             <CellAddressBadge>
+              <HiddenLabel text={intoOrOutFromText} />
               <AddressBadge address={address} truncate />
             </CellAddressBadge>
           )}
@@ -104,7 +110,7 @@ const TransactionalInfo = ({ transaction: tx, addressHash, className, hideLabel 
         </CellAddress>
       )}
       {amount && (
-        <CellAmount>
+        <CellAmount aria-hidden="true">
           <CellAmountInner>
             {type === 'out' ? '-' : '+'}
             <Amount value={amount} fadeDecimals />

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -72,9 +72,6 @@ const TransactionalInfo = ({ transaction: tx, addressHash, className, hideLabel 
     throw new Error('Could not determine transaction type, all transactions should have a type')
   }
 
-  const amountFormatted = formatAmountForDisplay(BigInt(amount ?? 0))
-  const intoOrOutFromText = type === 'out' ? t`out from` : t`into`
-
   return (
     <div className={className}>
       <CellAmountTokenTime>
@@ -82,7 +79,7 @@ const TransactionalInfo = ({ transaction: tx, addressHash, className, hideLabel 
           <DirectionalArrow direction={type} />
         </CellArrow>
         <TokenTimeInner>
-          <HiddenLabel text={amountFormatted} />
+          <HiddenLabel text={formatAmountForDisplay(BigInt(amount ?? 0))} />
           <TokenStyled type={token} />
           <TimeSince timestamp={timestamp} faded />
         </TokenTimeInner>
@@ -91,7 +88,7 @@ const TransactionalInfo = ({ transaction: tx, addressHash, className, hideLabel 
         <CellAddress>
           {!hideLabel && (
             <CellAddressBadge>
-              <HiddenLabel text={intoOrOutFromText} />
+              <HiddenLabel text={type === 'out' ? t`out from` : t`into`} />
               <AddressBadge address={address} truncate />
             </CellAddressBadge>
           )}

--- a/src/components/Truncate.tsx
+++ b/src/components/Truncate.tsx
@@ -16,9 +16,12 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { HTMLAttributes } from 'react'
 import styled from 'styled-components'
 
-export default styled(({ children, ...props }) => <div {...props}>{children}</div>)`
+const Truncate = ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props} />
+
+export default styled(Truncate)`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/Truncate.tsx
+++ b/src/components/Truncate.tsx
@@ -16,12 +16,9 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { FC } from 'react'
 import styled from 'styled-components'
 
-const Truncate: FC<{ className?: string }> = ({ className, children }) => <div className={className}>{children}</div>
-
-export default styled(Truncate)`
+export default styled(({ children, ...props }) => <div {...props}>{children}</div>)`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/WalletSummaryCard.tsx
+++ b/src/components/WalletSummaryCard.tsx
@@ -39,18 +39,18 @@ const WalletSummaryCard = ({ className, isLoading }: WalletSummaryCardProps) => 
   return (
     <div className={classNames(className, { 'skeleton-loader': isLoading })}>
       <div>
-        <AmountStyled value={totalBalance} />
-        <BalanceLabel>{t`TOTAL BALANCE`}</BalanceLabel>
+        <AmountStyled tabIndex={0} value={totalBalance} />
+        <BalanceLabel tabIndex={0} role="representation">{t`TOTAL BALANCE`}</BalanceLabel>
       </div>
       <Divider />
       <Balances>
         <Balance>
-          <Amount value={totalAvailableBalance} />
-          <BalanceLabel>{t`AVAILABLE`}</BalanceLabel>
+          <Amount tabIndex={0} value={totalAvailableBalance} />
+          <BalanceLabel tabIndex={0} role="representation">{t`AVAILABLE`}</BalanceLabel>
         </Balance>
         <Balance>
-          <Amount value={totalLockedBalance} />
-          <BalanceLabel>{t`LOCKED`}</BalanceLabel>
+          <Amount tabIndex={0} value={totalLockedBalance} />
+          <BalanceLabel tabIndex={0} role="representation">{t`LOCKED`}</BalanceLabel>
         </Balance>
       </Balances>
     </div>

--- a/src/hooks/useFocusOnMount.tsx
+++ b/src/hooks/useFocusOnMount.tsx
@@ -1,0 +1,27 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { useEffect, useRef } from 'react'
+
+export default function <T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+  useEffect(() => {
+    ref.current?.focus()
+  }, [ref])
+  return ref
+}

--- a/src/modals/AddressOptionsModal.tsx
+++ b/src/modals/AddressOptionsModal.tsx
@@ -27,6 +27,7 @@ import KeyValueInput from '../components/Inputs/InlineLabelValueInput'
 import HorizontalDivider from '../components/PageComponents/HorizontalDivider'
 import { Address, useAddressesContext } from '../contexts/addresses'
 import { useGlobalContext } from '../contexts/global'
+import useFocusOnMount from '../hooks/useFocusOnMount'
 import { getRandomLabelColor } from '../utils/colors'
 import AddressSweepModal from './AddressSweepModal'
 import CenteredModal, { ModalFooterButton, ModalFooterButtons } from './CenteredModal'
@@ -38,6 +39,7 @@ interface AddressOptionsModal {
 
 const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
   const { t } = useTranslation('App')
+  const divRef = useFocusOnMount<HTMLDivElement>()
   const { addresses, updateAddressSettings, mainAddress } = useAddressesContext()
   const [addressLabel, setAddressLabel] = useState({
     title: address?.settings.label ?? '',
@@ -72,7 +74,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
       : t`To remove this address from being the main address, you must set another one as main first.`
 
   return (
-    <>
+    <div ref={divRef} tabIndex={0}>
       <CenteredModal title={t`Address options`} subtitle={address.getName()} onClose={onClose}>
         {!isPassphraseUsed && (
           <>
@@ -100,7 +102,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
               >
                 {t`Sweep`}
               </ModalFooterButton>
-              <AvailableAmount>
+              <AvailableAmount tabIndex={0}>
                 {t`Available`}: <Amount value={address.availableBalance} color={theme.font.secondary} />
               </AvailableAmount>
             </SweepButton>
@@ -123,7 +125,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModal) => {
           />
         )}
       </AnimatePresence>
-    </>
+    </div>
   )
 }
 

--- a/src/modals/CenteredModal.tsx
+++ b/src/modals/CenteredModal.tsx
@@ -19,6 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { motion } from 'framer-motion'
 import { X } from 'lucide-react'
 import { FC, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
 import Button from '../components/Button'
@@ -26,6 +27,7 @@ import { Section } from '../components/PageComponents/PageContainers'
 import PanelTitle, { TitleContainer } from '../components/PageComponents/PanelTitle'
 import Scrollbar from '../components/Scrollbar'
 import Spinner from '../components/Spinner'
+import useFocusOnMount from '../hooks/useFocusOnMount'
 import ModalContainer, { ModalBackdrop, ModalContainerProps } from './ModalContainer'
 
 interface CenteredModalProps extends ModalContainerProps {
@@ -45,41 +47,49 @@ const CenteredModal: FC<CenteredModalProps> = ({
   header,
   narrow = false,
   children
-}) => (
-  <ModalContainer onClose={onClose} focusMode={focusMode} hasPadding>
-    <CenteredBox
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 20 }}
-      transition={{ duration: 0.2, ease: 'easeOut' }}
-      narrow={narrow}
-    >
-      <ModalHeader contrast={!!header}>
-        <TitleRow>
-          <PanelTitle smaller useLayoutId={false}>
-            {title}
-            {subtitle && <ModalSubtitle>{subtitle}</ModalSubtitle>}
-          </PanelTitle>
-          <CloseButton squared transparent onClick={onClose}>
-            <X />
-          </CloseButton>
-        </TitleRow>
-        {header && <ModalHeaderContent>{header}</ModalHeaderContent>}
-      </ModalHeader>
-      <Scrollbar translateContentSizeYToHolder>
-        <ModalContent>{children}</ModalContent>
-      </Scrollbar>
-      {isLoading && (
-        <>
-          <ModalBackdrop light />
-          <ModalLoadingSpinner>
-            <Spinner />
-          </ModalLoadingSpinner>
-        </>
-      )}
-    </CenteredBox>
-  </ModalContainer>
-)
+}) => {
+  const { t } = useTranslation('App')
+  const elRef = useFocusOnMount<HTMLSpanElement>()
+
+  return (
+    <ModalContainer onClose={onClose} focusMode={focusMode} hasPadding>
+      <CenteredBox
+        role="dialog"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 20 }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+        narrow={narrow}
+      >
+        <ModalHeader contrast={!!header}>
+          <TitleRow>
+            <PanelTitle smaller useLayoutId={false}>
+              <span ref={elRef} tabIndex={0} role="heading">
+                {title}
+              </span>
+              {subtitle && <ModalSubtitle>{subtitle}</ModalSubtitle>}
+            </PanelTitle>
+            <CloseButton aria-label={t`Close`} squared transparent onClick={onClose}>
+              <X />
+            </CloseButton>
+          </TitleRow>
+          {header && <ModalHeaderContent>{header}</ModalHeaderContent>}
+        </ModalHeader>
+        <Scrollbar translateContentSizeYToHolder>
+          <ModalContent>{children}</ModalContent>
+        </Scrollbar>
+        {isLoading && (
+          <>
+            <ModalBackdrop light />
+            <ModalLoadingSpinner>
+              <Spinner />
+            </ModalLoadingSpinner>
+          </>
+        )}
+      </CenteredBox>
+    </ModalContainer>
+  )
+}
 
 export default CenteredModal
 

--- a/src/modals/ModalContainer.tsx
+++ b/src/modals/ModalContainer.tsx
@@ -17,17 +17,18 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { motion } from 'framer-motion'
-import { FC, useCallback, useEffect } from 'react'
+import { ReactNode, useCallback, useEffect } from 'react'
 import styled from 'styled-components'
 
 export interface ModalContainerProps {
   onClose: () => void
+  children?: ReactNode | ReactNode[]
   focusMode?: boolean
   hasPadding?: boolean
   className?: string
 }
 
-const ModalContainer: FC<ModalContainerProps> = ({ children, onClose, focusMode, className }) => {
+const ModalContainer = ({ onClose, children, focusMode, className }: ModalContainerProps) => {
   // Prevent body scroll on mount
   useEffect(() => {
     document.body.style.overflow = 'hidden'

--- a/src/modals/NewAddressModal.tsx
+++ b/src/modals/NewAddressModal.tsx
@@ -86,12 +86,6 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
     onClose()
   }
 
-  const onGroupSelect = (newValue: SelectOption<number> | undefined) => {
-    if (newValue !== undefined) {
-      generateNewAddress(newValue.value)
-    }
-  }
-
   let mainAddressMessage = t`Default address for sending transactions.`
 
   if (mainAddress && wallet?.seed) {
@@ -100,6 +94,12 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
       mainAddress.index !== newAddressData?.addressIndex
         ? t(' Note that if activated, "{{ address }}" will not be the main address anymore.', { address })
         : ''
+  }
+
+  function onValueChange(newValue?: SelectOption<number>) {
+    if (newValue === undefined) return
+
+    generateNewAddress(newValue.value)
   }
 
   return (
@@ -133,7 +133,7 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
             label={t`Group`}
             controlledValue={newAddressGroup !== undefined ? generateGroupSelectOption(newAddressGroup) : undefined}
             options={Array.from(Array(TOTAL_NUMBER_OF_GROUPS)).map((_, index) => generateGroupSelectOption(index))}
-            onValueChange={onGroupSelect}
+            onValueChange={onValueChange}
             title={t`Select group`}
             id="group"
           />

--- a/src/modals/SendModal/TransactionForm.tsx
+++ b/src/modals/SendModal/TransactionForm.tsx
@@ -121,13 +121,20 @@ const SendModalTransactionForm = ({ data, onSubmit, onCancel }: TransactionFormP
           hideEmptyAvailableBalance
         />
         <Input
+          id="recipients-address"
           label={t`Recipient's address`}
+          aria-label={t`Recipient's address`}
           value={toAddress}
           onChange={(e) => handleAddressChange(e.target.value)}
           error={addressError}
           isValid={toAddress.length > 0 && !addressError}
         />
-        <AmountInput value={amount} onChange={setAmount} availableAmount={fromAddress.availableBalance} />
+        <AmountInput
+          id="amount-to-send"
+          value={amount}
+          onChange={setAmount}
+          availableAmount={fromAddress.availableBalance}
+        />
         {expectedFeeInALPH && (
           <InfoBoxStyled short label={t`Expected fee`}>
             {expectedFeeInALPH}

--- a/src/modals/SettingsModal/GeneralSettingsSection.tsx
+++ b/src/modals/SettingsModal/GeneralSettingsSection.tsx
@@ -54,6 +54,8 @@ const GeneralSettingsSection = () => {
     setIsPasswordModalOpen(false)
   }, [updateSettings])
 
+  const discreteModeText = t`Discrete mode`
+
   return (
     <>
       <KeyValueInput
@@ -61,6 +63,7 @@ const GeneralSettingsSection = () => {
         description={t`Duration in minutes after which an idle wallet will lock automatically.`}
         InputComponent={
           <Input
+            id="wallet-lock-time-in-minutes"
             value={walletLockTimeInMinutes || ''}
             onChange={(v) =>
               updateSettings('general', { walletLockTimeInMinutes: v.target.value ? parseInt(v.target.value) : null })
@@ -80,10 +83,14 @@ const GeneralSettingsSection = () => {
       />
       <HorizontalDivider narrow />
       <KeyValueInput
-        label={t`Discreet mode`}
+        label={discreteModeText}
         description={t`Toggle discreet mode (hide amounts).`}
         InputComponent={
-          <Toggle toggled={discreetMode} onToggle={() => updateSettings('general', { discreetMode: !discreetMode })} />
+          <Toggle
+            label={discreteModeText}
+            toggled={discreetMode}
+            onToggle={() => updateSettings('general', { discreetMode: !discreetMode })}
+          />
         }
       />
       <HorizontalDivider narrow />

--- a/src/modals/SettingsModal/NetworkSettingsSection.tsx
+++ b/src/modals/SettingsModal/NetworkSettingsSection.tsx
@@ -26,7 +26,7 @@ import Button from '../../components/Button'
 import ExpandableSection from '../../components/ExpandableSection'
 import InfoBox from '../../components/InfoBox'
 import Input from '../../components/Inputs/Input'
-import Select from '../../components/Inputs/Select'
+import Select, { SelectOption } from '../../components/Inputs/Select'
 import { Section } from '../../components/PageComponents/PageContainers'
 import { useGlobalContext } from '../../contexts/global'
 import { useMountEffect } from '../../utils/hooks'
@@ -72,18 +72,18 @@ const NetworkSettingsSection = () => {
   }
 
   const handleNetworkPresetChange = useCallback(
-    (option: typeof networkSelectOptions[number] | undefined) => {
-      if (option && option.value !== selectedNetwork) {
-        setSelectedNetwork(option.value)
+    (option?: SelectOption<NetworkName>) => {
+      if (option === undefined || option.value === selectedNetwork) return
 
-        if (option.value === 'custom') {
-          // Make sure to open expandable advanced section
-          setAdvancedSectionOpen(true)
-        } else {
-          const newNetworkSettings = networkEndpoints[option.value]
-          updateNetworkSettings(newNetworkSettings)
-          setTempAdvancedSettings(newNetworkSettings)
-        }
+      setSelectedNetwork(option.value)
+
+      if (option.value === 'custom') {
+        // Make sure to open expandable advanced section
+        setAdvancedSectionOpen(true)
+      } else {
+        const newNetworkSettings = networkEndpoints[option.value]
+        updateNetworkSettings(newNetworkSettings)
+        setTempAdvancedSettings(newNetworkSettings)
       }
     },
     [selectedNetwork, updateNetworkSettings]
@@ -121,16 +121,19 @@ const NetworkSettingsSection = () => {
       >
         <UrlInputs>
           <Input
+            id="node-host"
             label={t`Node host`}
             value={tempAdvancedSettings.nodeHost}
             onChange={(e) => editAdvancedSettings({ nodeHost: e.target.value })}
           />
           <Input
+            id="explorer-api-host"
             label={t`Explorer API host`}
             value={tempAdvancedSettings.explorerApiHost}
             onChange={(e) => editAdvancedSettings({ explorerApiHost: e.target.value })}
           />
           <Input
+            id="explorer-url"
             label={t`Explorer URL`}
             value={tempAdvancedSettings.explorerUrl}
             onChange={(e) => editAdvancedSettings({ explorerUrl: e.target.value })}

--- a/src/modals/SettingsModal/WalletsSettingsSection.tsx
+++ b/src/modals/SettingsModal/WalletsSettingsSection.tsx
@@ -56,11 +56,11 @@ const WalletsSettingsSection = () => {
           onWalletRemove={() => handleRemoveWallet(walletToRemove)}
         />
       )}
-      <Section align="flex-start">
-        <h2>
+      <Section align="flex-start" role="table">
+        <h2 tabIndex={0} role="label">
           {t`Wallet list`} ({walletNames.length})
         </h2>
-        <BoxContainer>
+        <BoxContainer role="rowgroup">
           {walletNames.map((n) => (
             <WalletItem
               key={n}
@@ -107,15 +107,23 @@ const WalletItem = ({ walletName, isCurrent, onWalletDelete }: WalletItemProps) 
 
   return (
     <WalletItemContainer
+      role="row"
       onMouseEnter={() => setIsShowingDeleteButton(true)}
       onMouseLeave={() => setIsShowingDeleteButton(false)}
     >
-      <WalletName>
+      <WalletName role="cell" tabIndex={0} onFocus={() => setIsShowingDeleteButton(true)}>
         {walletName}
         {isCurrent && <CurrentWalletLabel> {t`(current)`}</CurrentWalletLabel>}
       </WalletName>
       {isShowingDeleteButton && (
-        <WalletDeleteButton squared transparent onClick={() => onWalletDelete(walletName)}>
+        <WalletDeleteButton
+          aria-label={t`Delete`}
+          tabIndex={0}
+          squared
+          transparent
+          onClick={() => onWalletDelete(walletName)}
+          onBlur={() => setIsShowingDeleteButton(false)}
+        >
           <Trash size={15} />
         </WalletDeleteButton>
       )}

--- a/src/modals/SideModal.tsx
+++ b/src/modals/SideModal.tsx
@@ -17,23 +17,34 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { motion } from 'framer-motion'
-import { FC } from 'react'
 import styled from 'styled-components'
 
+import useFocusOnMount from '../hooks/useFocusOnMount'
 import ModalContainer, { ModalContainerProps } from './ModalContainer'
 
-const SideModal: FC<ModalContainerProps> = ({ onClose, children }) => (
-  <ModalContainer onClose={onClose}>
-    <Sidebar
-      initial={{ x: '100%' }}
-      animate={{ x: 0 }}
-      exit={{ x: '100%' }}
-      transition={{ duration: 0.2, ease: 'easeOut' }}
-    >
-      {children}
-    </Sidebar>
-  </ModalContainer>
-)
+interface SideModalProps extends ModalContainerProps {
+  label: string
+}
+
+const SideModal = ({ onClose, children, label }: SideModalProps) => {
+  const elRef = useFocusOnMount<HTMLDivElement>()
+
+  return (
+    <ModalContainer onClose={onClose}>
+      <Sidebar
+        role="dialog"
+        initial={{ x: '100%' }}
+        animate={{ x: 0 }}
+        exit={{ x: '100%' }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+      >
+        <div ref={elRef} tabIndex={0} aria-label={label}>
+          {children}
+        </div>
+      </Sidebar>
+    </ModalContainer>
+  )
+}
 
 export default SideModal
 

--- a/src/modals/SideModal.tsx
+++ b/src/modals/SideModal.tsx
@@ -19,6 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { motion } from 'framer-motion'
 import styled from 'styled-components'
 
+import Scrollbar from '../components/Scrollbar'
 import useFocusOnMount from '../hooks/useFocusOnMount'
 import ModalContainer, { ModalContainerProps } from './ModalContainer'
 
@@ -38,9 +39,11 @@ const SideModal = ({ onClose, children, label }: SideModalProps) => {
         exit={{ x: '100%' }}
         transition={{ duration: 0.2, ease: 'easeOut' }}
       >
-        <div ref={elRef} tabIndex={0} aria-label={label}>
-          {children}
-        </div>
+        <Scrollbar>
+          <div ref={elRef} tabIndex={0} aria-label={label}>
+            {children}
+          </div>
+        </Scrollbar>
       </Sidebar>
     </ModalContainer>
   )

--- a/src/modals/TransactionDetailsModal.tsx
+++ b/src/modals/TransactionDetailsModal.tsx
@@ -67,7 +67,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
   }
 
   return (
-    <SideModal onClose={onClose}>
+    <SideModal onClose={onClose} label={t`Transaction details`}>
       <Header contrast>
         <AmountWrapper tabIndex={0} color={isOutgoingTx ? theme.font.secondary : theme.global.valid}>
           <span>{isOutgoingTx ? '-' : '+'}</span>{' '}

--- a/src/modals/TransactionDetailsModal.tsx
+++ b/src/modals/TransactionDetailsModal.tsx
@@ -29,7 +29,6 @@ import Amount from '../components/Amount'
 import Badge from '../components/Badge'
 import ExpandableSection from '../components/ExpandableSection'
 import IOList from '../components/IOList'
-import Scrollbar from '../components/Scrollbar'
 import { Address } from '../contexts/addresses'
 import { useGlobalContext } from '../contexts/global'
 import useAddressLinkHandler from '../hooks/useAddressLinkHandler'
@@ -80,82 +79,80 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         </HeaderInfo>
         <ActionLink onClick={handleShowTxInExplorer}>↗ {t`Show in explorer`}</ActionLink>
       </Header>
-      <Scrollbar>
-        <Details role="table">
-          <DetailsRow label={t`From`}>
-            {isOutgoingTx ? (
-              <ActionLink onClick={() => handleShowAddress(address.hash)} key={address.hash}>
-                <AddressBadge address={address} truncate />
-              </ActionLink>
-            ) : (
-              <IOList
-                currentAddress={address.hash}
-                isOut={isOutgoingTx}
-                outputs={transaction.outputs}
-                inputs={transaction.inputs}
-                timestamp={transaction.timestamp}
-                linkToExplorer
-              />
-            )}
+      <Details role="table">
+        <DetailsRow label={t`From`}>
+          {isOutgoingTx ? (
+            <ActionLink onClick={() => handleShowAddress(address.hash)} key={address.hash}>
+              <AddressBadge address={address} truncate />
+            </ActionLink>
+          ) : (
+            <IOList
+              currentAddress={address.hash}
+              isOut={isOutgoingTx}
+              outputs={transaction.outputs}
+              inputs={transaction.inputs}
+              timestamp={transaction.timestamp}
+              linkToExplorer
+            />
+          )}
+        </DetailsRow>
+        <DetailsRow label={t`To`}>
+          {!isOutgoingTx ? (
+            <ActionLink onClick={() => handleShowAddress(address.hash)} key={address.hash}>
+              <AddressBadge address={address} />
+            </ActionLink>
+          ) : (
+            <IOList
+              currentAddress={address.hash}
+              isOut={isOutgoingTx}
+              outputs={transaction.outputs}
+              inputs={transaction.inputs}
+              timestamp={transaction.timestamp}
+              linkToExplorer
+            />
+          )}
+        </DetailsRow>
+        <DetailsRow label={t`Status`}>
+          <Badge color={theme.global.valid} border>
+            <span tabIndex={0}>{t`Confirmed`}</span>
+          </Badge>
+        </DetailsRow>
+        <DetailsRow label={t`Timestamp`}>
+          <span tabIndex={0}>{dayjs(transaction.timestamp).format('YYYY-MM-DD [at] HH:mm:ss [UTC]Z')}</span>
+        </DetailsRow>
+        <DetailsRow label={t`Fee`}>
+          {<Amount tabIndex={0} value={BigInt(transaction.gasAmount) * BigInt(transaction.gasPrice)} fadeDecimals />}
+        </DetailsRow>
+        <DetailsRow label={t`Total value`}>
+          <Amount tabIndex={0} value={amount} fadeDecimals fullPrecision />
+        </DetailsRow>
+        <ExpandableSectionStyled sectionTitleClosed={t`Click to see more`} sectionTitleOpen={t`Click to see less`}>
+          <DetailsRow label={t`Gas amount`}>
+            <span tabIndex={0}>{addApostrophes(transaction.gasAmount.toString())}</span>
           </DetailsRow>
-          <DetailsRow label={t`To`}>
-            {!isOutgoingTx ? (
-              <ActionLink onClick={() => handleShowAddress(address.hash)} key={address.hash}>
-                <AddressBadge address={address} />
-              </ActionLink>
-            ) : (
-              <IOList
-                currentAddress={address.hash}
-                isOut={isOutgoingTx}
-                outputs={transaction.outputs}
-                inputs={transaction.inputs}
-                timestamp={transaction.timestamp}
-                linkToExplorer
-              />
-            )}
+          <DetailsRow label={t`Gas price`}>
+            <Amount tabIndex={0} value={BigInt(transaction.gasPrice)} fadeDecimals fullPrecision />
           </DetailsRow>
-          <DetailsRow label={t`Status`}>
-            <Badge color={theme.global.valid} border>
-              <span tabIndex={0}>{t`Confirmed`}</span>
-            </Badge>
+          <DetailsRow label={t`Inputs`}>
+            <IOs>
+              {transaction.inputs?.map((input) => (
+                <ActionLink key={`${input.outputRef.key}`} onClick={() => handleShowAddress(input.address)}>
+                  {input.address}
+                </ActionLink>
+              ))}
+            </IOs>
           </DetailsRow>
-          <DetailsRow label={t`Timestamp`}>
-            <span tabIndex={0}>{dayjs(transaction.timestamp).format('YYYY-MM-DD [at] HH:mm:ss [UTC]Z')}</span>
+          <DetailsRow label={t`Outputs`}>
+            <IOs>
+              {transaction.outputs?.map((output) => (
+                <ActionLink key={`${output.key}`} onClick={() => handleShowAddress(output.address)}>
+                  {output.address}
+                </ActionLink>
+              ))}
+            </IOs>
           </DetailsRow>
-          <DetailsRow label={t`Fee`}>
-            {<Amount tabIndex={0} value={BigInt(transaction.gasAmount) * BigInt(transaction.gasPrice)} fadeDecimals />}
-          </DetailsRow>
-          <DetailsRow label={t`Total value`}>
-            <Amount tabIndex={0} value={amount} fadeDecimals fullPrecision />
-          </DetailsRow>
-          <ExpandableSectionStyled sectionTitleClosed={t`Click to see more`} sectionTitleOpen={t`Click to see less`}>
-            <DetailsRow label={t`Gas amount`}>
-              <span tabIndex={0}>{addApostrophes(transaction.gasAmount.toString())}</span>
-            </DetailsRow>
-            <DetailsRow label={t`Gas price`}>
-              <Amount tabIndex={0} value={BigInt(transaction.gasPrice)} fadeDecimals fullPrecision />
-            </DetailsRow>
-            <DetailsRow label={t`Inputs`}>
-              <IOs>
-                {transaction.inputs?.map((input) => (
-                  <ActionLink key={`${input.outputRef.key}`} onClick={() => handleShowAddress(input.address)}>
-                    {input.address}
-                  </ActionLink>
-                ))}
-              </IOs>
-            </DetailsRow>
-            <DetailsRow label={t`Outputs`}>
-              <IOs>
-                {transaction.outputs?.map((output) => (
-                  <ActionLink key={`${output.key}`} onClick={() => handleShowAddress(output.address)}>
-                    {output.address}
-                  </ActionLink>
-                ))}
-              </IOs>
-            </DetailsRow>
-          </ExpandableSectionStyled>
-        </Details>
-      </Scrollbar>
+        </ExpandableSectionStyled>
+      </Details>
     </SideModal>
   )
 }

--- a/src/modals/TransactionDetailsModal.tsx
+++ b/src/modals/TransactionDetailsModal.tsx
@@ -69,7 +69,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
   return (
     <SideModal onClose={onClose}>
       <Header contrast>
-        <AmountWrapper color={isOutgoingTx ? theme.font.secondary : theme.global.valid}>
+        <AmountWrapper tabIndex={0} color={isOutgoingTx ? theme.font.secondary : theme.global.valid}>
           <span>{isOutgoingTx ? '-' : '+'}</span>{' '}
           <Amount value={amount} fadeDecimals color={isOutgoingTx ? theme.font.secondary : theme.global.valid} />
         </AmountWrapper>
@@ -81,7 +81,7 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
         <ActionLink onClick={handleShowTxInExplorer}>↗ {t`Show in explorer`}</ActionLink>
       </Header>
       <Scrollbar>
-        <Details>
+        <Details role="table">
           <DetailsRow label={t`From`}>
             {isOutgoingTx ? (
               <ActionLink onClick={() => handleShowAddress(address.hash)} key={address.hash}>
@@ -116,20 +116,24 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
           </DetailsRow>
           <DetailsRow label={t`Status`}>
             <Badge color={theme.global.valid} border>
-              {t`Confirmed`}
+              <span tabIndex={0}>{t`Confirmed`}</span>
             </Badge>
           </DetailsRow>
           <DetailsRow label={t`Timestamp`}>
-            {dayjs(transaction.timestamp).format('YYYY-MM-DD [at] HH:mm:ss [UTC]Z')}
+            <span tabIndex={0}>{dayjs(transaction.timestamp).format('YYYY-MM-DD [at] HH:mm:ss [UTC]Z')}</span>
           </DetailsRow>
           <DetailsRow label={t`Fee`}>
-            {<Amount value={BigInt(transaction.gasAmount) * BigInt(transaction.gasPrice)} fadeDecimals />}
+            {<Amount tabIndex={0} value={BigInt(transaction.gasAmount) * BigInt(transaction.gasPrice)} fadeDecimals />}
           </DetailsRow>
-          <DetailsRow label={t`Total value`}>{<Amount value={amount} fadeDecimals fullPrecision />}</DetailsRow>
+          <DetailsRow label={t`Total value`}>
+            <Amount tabIndex={0} value={amount} fadeDecimals fullPrecision />
+          </DetailsRow>
           <ExpandableSectionStyled sectionTitleClosed={t`Click to see more`} sectionTitleOpen={t`Click to see less`}>
-            <DetailsRow label={t`Gas amount`}>{addApostrophes(transaction.gasAmount.toString())}</DetailsRow>
+            <DetailsRow label={t`Gas amount`}>
+              <span tabIndex={0}>{addApostrophes(transaction.gasAmount.toString())}</span>
+            </DetailsRow>
             <DetailsRow label={t`Gas price`}>
-              <Amount value={BigInt(transaction.gasPrice)} fadeDecimals fullPrecision />
+              <Amount tabIndex={0} value={BigInt(transaction.gasPrice)} fadeDecimals fullPrecision />
             </DetailsRow>
             <DetailsRow label={t`Inputs`}>
               <IOs>
@@ -159,8 +163,10 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
 export default TransactionDetailsModal
 
 let DetailsRow: FC<DetailsRowProps> = ({ children, label, className }) => (
-  <div className={className}>
-    <DetailsRowLabel>{label}</DetailsRowLabel>
+  <div className={className} role="row">
+    <DetailsRowLabel tabIndex={0} role="cell">
+      {label}
+    </DetailsRowLabel>
     {children}
   </div>
 )

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -21,8 +21,8 @@ import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import styled from 'styled-components'
-import tinycolor from 'tinycolor2'
 
+import ActionLink from '../components/ActionLink'
 import AppHeader from '../components/AppHeader'
 import Button from '../components/Button'
 import SideBar from '../components/HomePage/SideBar'
@@ -142,16 +142,14 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
           {t`Login`}
         </Button>
       </SectionStyled>
-      <SwitchLink onClick={onLinkClick} centered>
-        {t`Create / import a new wallet`}
-      </SwitchLink>
+      <SwitchLink onClick={onLinkClick}>{t`Create / import a new wallet`}</SwitchLink>
     </>
   )
 }
 
 const InitialActions = ({
   showLinkToExistingWallets,
-  onLinkClick
+  onLinkClick = () => ({})
 }: {
   showLinkToExistingWallets?: boolean
   onLinkClick?: () => void
@@ -165,13 +163,9 @@ const InitialActions = ({
         {t`Please choose whether you want to create a new wallet or import an existing one.`}
       </Paragraph>
       <Section inList>
-        <Button onClick={() => navigate('/create/0')}>{t`New wallet`}</Button>
-        <Button onClick={() => navigate('/import/0')}>{t`Import wallet`}</Button>
-        {showLinkToExistingWallets && (
-          <SwitchLink onClick={onLinkClick} centered>
-            {t`Use an existing wallet`}
-          </SwitchLink>
-        )}
+        <Button onClick={() => navigate('/create/0')}>New wallet</Button>
+        <Button onClick={() => navigate('/import/0')}>Import wallet</Button>
+        {showLinkToExistingWallets && <SwitchLink onClick={onLinkClick}>{t`Use an existing wallet`}</SwitchLink>}
       </Section>
     </>
   )
@@ -198,17 +192,13 @@ const InteractionArea = styled.div`
   padding: var(--spacing-5);
 `
 
-const SwitchLink = styled(Paragraph)`
-  color: ${({ theme }) => theme.global.accent};
-  background-color: ${({ theme }) => theme.bg.primary};
-  padding: var(--spacing-1);
-  cursor: pointer;
-
-  &:hover {
-    color: ${({ theme }) => tinycolor(theme.global.accent).darken(10).toString()};
-  }
-`
-
 const SectionStyled = styled(Section)`
   min-width: 400px;
+`
+
+const SwitchLink = styled(ActionLink)`
+  font-weight: var(--fontWeight-medium);
+  font-size: 12px;
+  font-family: inherit;
+  height: var(--inputHeight);
 `

--- a/src/pages/Wallet/AddressDetailsPage.tsx
+++ b/src/pages/Wallet/AddressDetailsPage.tsx
@@ -65,11 +65,13 @@ const AddressDetailsPage = () => {
     setSelectedTransaction(transaction)
   }
 
+  const goBack = () => navigate(-1)
+
   return (
     <MainContent>
       <PageTitleRow>
         <Title>
-          <ArrowLeftStyled onClick={() => navigate(-1)} />
+          <ArrowLeftStyled role="button" tabIndex={0} onClick={goBack} onKeyPress={goBack} />
           <PageH1Styled>
             {t`Address details`} {address.settings.isMain && !isPassphraseUsed && <MainAddressLabelStyled />}
           </PageH1Styled>
@@ -84,11 +86,13 @@ const AddressDetailsPage = () => {
           </OptionsButton>
         </Title>
       </PageTitleRow>
-      <DataList>
-        <DataListRow>
-          <DataListCell>{t`Address`}</DataListCell>
+      <DataList role="grid" tabIndex={0}>
+        <DataListRow role="row">
+          <DataListCell role="gridcell" tabIndex={0}>{t`Address`}</DataListCell>
           <DataListCell>
-            <Truncate>{addressHash}</Truncate>
+            <Truncate role="gridcell" tabIndex={0}>
+              {addressHash}
+            </Truncate>
             <IconButtons>
               <ClipboardButton textToCopy={addressHash} />
               <QRCodeButton textToEncode={addressHash} />
@@ -96,27 +100,39 @@ const AddressDetailsPage = () => {
             </IconButtons>
           </DataListCell>
         </DataListRow>
-        <DataListRow>
-          <DataListCell>Label</DataListCell>
-          <DataListCell>{address.settings.label ? <AddressBadge address={address} truncate /> : '-'}</DataListCell>
+        <DataListRow role="row">
+          <DataListCell role="gridcell" tabIndex={0}>
+            Label
+          </DataListCell>
+          <DataListCell role="gridcell" tabIndex={0}>
+            {address.settings.label ? <AddressBadge address={address} truncate /> : '-'}
+          </DataListCell>
         </DataListRow>
-        <DataListRow>
-          <DataListCell>{t`Number of transactions`}</DataListCell>
-          <DataListCell>{address.details?.txNumber}</DataListCell>
+        <DataListRow role="row">
+          <DataListCell role="gridcell" tabIndex={0}>
+            {t`Number of transactions`}
+          </DataListCell>
+          <DataListCell role="gridcell" tabIndex={0}>
+            {address.details?.txNumber}
+          </DataListCell>
         </DataListRow>
         {address.details?.lockedBalance && BigInt(address.details.lockedBalance) > 0 && (
-          <DataListRow>
-            <DataListCell>{t`Locked ALPH balance`}</DataListCell>
-            <DataListCell>
+          <DataListRow role="row">
+            <DataListCell role="gridcell" tabIndex={0}>
+              {t`Locked ALPH balance`}
+            </DataListCell>
+            <DataListCell role="gridcell" tabIndex={0}>
               <Badge>
                 <Amount value={BigInt(address.details.lockedBalance)} fadeDecimals />
               </Badge>
             </DataListCell>
           </DataListRow>
         )}
-        <DataListRow>
-          <DataListCell>{t`Total ALPH balance`}</DataListCell>
-          <DataListCell>
+        <DataListRow role="row">
+          <DataListCell role="gridcell" tabIndex={0}>
+            {t`Total ALPH balance`}
+          </DataListCell>
+          <DataListCell role="gridcell" tabIndex={0}>
             {address.details?.balance ? (
               <Badge border>
                 <Amount value={BigInt(address.details.balance)} fadeDecimals />
@@ -133,25 +149,33 @@ const AddressDetailsPage = () => {
           .slice(0)
           .reverse()
           .map((transaction) => (
-            <TableRow key={transaction.txId} blinking>
+            <TableRow role="row" tabIndex={0} key={transaction.txId} blinking>
               {transaction.type === 'transfer' && <TransactionalInfo hideLabel transaction={transaction} />}
             </TableRow>
           ))}
         {address.transactions.confirmed.map((transaction) => (
-          <TableRow key={transaction.hash} onClick={() => onTransactionClick(transaction)}>
+          <TableRow
+            role="row"
+            tabIndex={0}
+            key={transaction.hash}
+            onClick={() => onTransactionClick(transaction)}
+            onKeyPress={() => onTransactionClick(transaction)}
+          >
             <TransactionalInfo hideLabel transaction={transaction} />
           </TableRow>
         ))}
         {address.transactions.confirmed.length !== address.details.txNumber && (
-          <TableRow>
-            <TableCell align="center">
+          <TableRow role="row">
+            <TableCell align="center" role="gridcell">
               <ActionLink onClick={loadNextTransactionsPage}>{t`Show more`}</ActionLink>
             </TableCell>
           </TableRow>
         )}
         {address.transactions.pending.length === 0 && address.transactions.confirmed.length === 0 && (
-          <TableRow>
-            <TableCellPlaceholder align="center">{t`No transactions to display`}</TableCellPlaceholder>
+          <TableRow role="row" tabIndex={0}>
+            <TableCellPlaceholder align="center" role="gridcell">
+              {t`No transactions to display`}
+            </TableCellPlaceholder>
           </TableRow>
         )}
       </Table>

--- a/src/pages/Wallet/AddressesPage.tsx
+++ b/src/pages/Wallet/AddressesPage.tsx
@@ -65,9 +65,7 @@ const AddressesPage = () => {
   const { isPassphraseUsed } = useGlobalContext()
   const theme = useTheme()
 
-  const navigateToAddressDetailsPage = (addressHash: AddressHash) => {
-    navigate(`/wallet/addresses/${addressHash}`)
-  }
+  const navigateToAddressDetailsPage = (addressHash: AddressHash) => () => navigate(`/wallet/addresses/${addressHash}`)
 
   const handleOneAddressPerGroupClick = () => {
     if (isPassphraseUsed) {
@@ -92,15 +90,23 @@ const AddressesPage = () => {
           <TableRow
             key={address.hash}
             columnWidths={tableColumnWidths}
-            onClick={() => navigateToAddressDetailsPage(address.hash)}
+            role="row"
+            onClick={navigateToAddressDetailsPage(address.hash)}
+            onKeyPress={navigateToAddressDetailsPage(address.hash)}
           >
-            <TableCell>
+            <TableCell role="cell" tabIndex={0}>
               <AddressBadge address={address} truncate />
             </TableCell>
-            <TableCell>{address.lastUsed ? dayjs(address.lastUsed).fromNow() : '-'}</TableCell>
-            <TableCell>{address.details?.txNumber ?? 0}</TableCell>
-            <TableCell>{address.group}</TableCell>
-            <TableCellAmount align="end">
+            <TableCell role="cell" tabIndex={0}>
+              {address.lastUsed ? dayjs(address.lastUsed).fromNow() : '-'}
+            </TableCell>
+            <TableCell role="cell" tabIndex={0}>
+              {address.details?.txNumber ?? 0}
+            </TableCell>
+            <TableCell role="cell" tabIndex={0}>
+              {address.group}
+            </TableCell>
+            <TableCellAmount role="cell" tabIndex={0} align="end">
               {address.transactions.pending.length > 0 && <Spinner size="12px" />}
               <Amount value={BigInt(address.details?.balance ?? 0)} fadeDecimals />
             </TableCellAmount>
@@ -110,7 +116,7 @@ const AddressesPage = () => {
           <TableCell>
             <ActionLink onClick={() => setIsGenerateNewAddressModalOpen(true)}>+ {t`Generate new address`}</ActionLink>
           </TableCell>
-          <Summary align="end">
+          <Summary role="cell" tabIndex={0} align="end">
             <Badge border>
               <Amount value={balanceSummary} fadeDecimals />
             </Badge>

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -125,7 +125,7 @@ const WalletLayout: FC = ({ children }) => {
           <InfoBox text={activeWalletName} label={t`WALLET`} />
         ) : (
           <Select
-            label={t`WALLET`}
+            label={t`CURRENT WALLET`}
             options={walletNameSelectOptions}
             controlledValue={{
               label: activeWalletName,
@@ -230,7 +230,7 @@ const WalletSidebar = styled.div`
   }
 `
 
-const WalletActions = styled.div`
+const WalletActions = styled.nav`
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/src/pages/WalletManagement/CheckWordsIntroPage.tsx
+++ b/src/pages/WalletManagement/CheckWordsIntroPage.tsx
@@ -65,9 +65,7 @@ const CheckWordsIntroPage = () => {
         </Section>
       </PanelContentContainer>
       <FooterActionsContainer apparitionDelay={0.3}>
-        <Button onClick={onButtonNext} submit>
-          {t`Ready!`}
-        </Button>
+        <Button onClick={onButtonNext}>{t`Ready!`}</Button>
       </FooterActionsContainer>
     </FloatingPanel>
   )

--- a/src/pages/WalletManagement/CheckWordsPage.tsx
+++ b/src/pages/WalletManagement/CheckWordsPage.tsx
@@ -225,7 +225,7 @@ const CheckWordsPage = () => {
           <Button secondary onClick={onButtonBack}>
             {t`Cancel`}
           </Button>
-          <Button onClick={handleButtonNext} disabled={!areWordsValid} submit>
+          <Button onClick={handleButtonNext} disabled={!areWordsValid}>
             {t`Continue`}
           </Button>
         </FooterActionsContainer>
@@ -248,7 +248,7 @@ const RemainingWordList = styled.div`
   align-content: flex-start;
 `
 
-const SelectedWord = styled(motion.div)`
+const SelectedWord = styled(motion.button)`
   padding: 6px var(--spacing-2);
   border-radius: 5px;
   background-color: ${({ theme }) => theme.global.accent};
@@ -265,6 +265,10 @@ const SelectedWord = styled(motion.div)`
 
   &:hover {
     background-color: ${({ theme }) => tinycolor(theme.global.accent).setAlpha(0.8).toString()};
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px ${({ theme }) => tinycolor(theme.global.accent).darken(20).toString()};
   }
 `
 

--- a/src/pages/WalletManagement/CreateWalletPage.tsx
+++ b/src/pages/WalletManagement/CreateWalletPage.tsx
@@ -135,7 +135,7 @@ const CreateWalletPage = ({ isRestoring = false }: { isRestoring?: boolean }) =>
         <Button secondary onClick={onButtonBack}>
           {t`Back`}
         </Button>
-        <Button disabled={!isNextButtonActive} onClick={handleNextButtonClick} submit>
+        <Button disabled={!isNextButtonActive} onClick={handleNextButtonClick}>
           {t`Continue`}
         </Button>
       </FooterActionsContainer>

--- a/src/pages/WalletManagement/WalletWordsPage.tsx
+++ b/src/pages/WalletManagement/WalletWordsPage.tsx
@@ -71,9 +71,7 @@ const WalletWordsPage = () => {
         </WordsContent>
       </PanelContentContainer>
       <FooterActionsContainer apparitionDelay={0.3}>
-        <Button onClick={onButtonNext} submit>
-          {t`I've copied the words, continue`}
-        </Button>
+        <Button onClick={onButtonNext}>{t`I've copied the words, continue`}</Button>
       </FooterActionsContainer>
     </FloatingPanel>
   )


### PR DESCRIPTION
Making my way through a list I've made:

* [x] Wallet selection modal cannot be triggered
* [x] Create / import wallet cannot be highlighted
* [x] Wallet words cannot be selected
* [x] Settings tabs cannot be changed
* [x] Any toggle cannot be highlighted
* [x] Expanding sections cannot be highlighted
* [x] Wallets cannot be deleted
* [x] Menu cannot be navigated to
* [x] Link buttons are not highlighted (but can be triggered)
* [x] Transaction history rows cannot be highlighted
* [x] Addresses rows cannot be highlighted
* [x] More info links cannot be highlighted
* [x] Address color cannot be highlighted
* [x] Address color selector cannot be closed without closing the entire modal
* [x] Address selector cannot be highlighted
* [x] Clipboard in address details cannot be highlighted
* [x] Back button in address details cannot be highlighted
* [x] Label in address details cannot be highlighted
* [x] Number of transactions cannot be highlighted
* [x] Total ALPH balance cannot be highlighted
* [x] Nothing in the transaction side pull-out can be highlighted
* [x] Nothing in the Security Check can be highlighted
* [x] Back button in wallet creation can't be highlighted

