### PR TITLE
Ilias reflect wallet delete

### DIFF
--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -55,7 +55,7 @@ export interface GlobalContextProps {
   saveWallet: (walletName: string, wallet: Wallet, password: string) => void
   deleteWallet: (w: string) => void
   lockWallet: () => void
-  login: (walletName: string, password: string, callback: () => void, passphrase?: string) => void
+  unlockWallet: (walletName: string, password: string, callback: () => void, passphrase?: string) => void
   client: Client | undefined
   settings: Settings
   updateSettings: UpdateSettingsFunctionSignature
@@ -79,7 +79,7 @@ export const initialGlobalContext: GlobalContextProps = {
   saveWallet: () => null,
   deleteWallet: () => null,
   lockWallet: () => null,
-  login: () => null,
+  unlockWallet: () => null,
   client: undefined,
   settings: localStorageSettings,
   updateSettings: () => null,
@@ -146,7 +146,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
     setWallet(undefined)
   }
 
-  const login = async (walletName: string, password: string, callback: () => void, passphrase?: string) => {
+  const unlockWallet = async (walletName: string, password: string, callback: () => void, passphrase?: string) => {
     const walletEncrypted = Storage.load(walletName)
 
     if (!walletEncrypted) {
@@ -246,7 +246,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
           saveWallet,
           deleteWallet,
           lockWallet,
-          login,
+          unlockWallet,
           client,
           snackbarMessage,
           setSnackbarMessage,

--- a/src/modals/SettingsModal/WalletsSettingsSection.tsx
+++ b/src/modals/SettingsModal/WalletsSettingsSection.tsx
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { getStorage } from '@alephium/sdk'
 import { Trash } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -27,15 +26,12 @@ import InfoBox from '../../components/InfoBox'
 import HorizontalDivider from '../../components/PageComponents/HorizontalDivider'
 import { BoxContainer, Section } from '../../components/PageComponents/PageContainers'
 import { useGlobalContext } from '../../contexts/global'
-import { deleteStoredAddressMetadataOfWallet } from '../../utils/addresses'
 import SecretPhraseModal from '../SecretPhraseModal'
 import WalletRemovalModal from '../WalletRemovalModal'
 
-const Storage = getStorage()
-
 const WalletsSettingsSection = () => {
   const { t } = useTranslation('App')
-  const { activeWalletName, wallet, walletNames, setWalletNames, lockWallet } = useGlobalContext()
+  const { activeWalletName, wallet, walletNames, deleteWallet, lockWallet } = useGlobalContext()
   const [isDisplayingSecretModal, setIsDisplayingSecretModal] = useState(false)
   const [walletToRemove, setWalletToRemove] = useState<string>('')
 
@@ -44,9 +40,7 @@ const WalletsSettingsSection = () => {
   const closeSecretPhraseModal = () => setIsDisplayingSecretModal(false)
 
   const handleRemoveWallet = (walletName: string) => {
-    Storage.remove(walletName)
-    deleteStoredAddressMetadataOfWallet(walletName)
-    setWalletNames(Storage.list())
+    deleteWallet(walletName)
 
     walletName === activeWalletName ? lockWallet() : setWalletToRemove('')
   }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -97,7 +97,7 @@ interface LoginProps {
 const Login = ({ walletNames, onLinkClick }: LoginProps) => {
   const { t } = useTranslation('App')
   const [credentials, setCredentials] = useState({ walletName: '', password: '' })
-  const { login } = useGlobalContext()
+  const { unlockWallet } = useGlobalContext()
   const navigate = useNavigate()
   const [passphrase, setPassphrase] = useState('')
   const [isPassphraseConfirmed, setIsPassphraseConfirmed] = useState(false)
@@ -108,7 +108,7 @@ const Login = ({ walletNames, onLinkClick }: LoginProps) => {
 
   const handleLogin = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault()
-    login(credentials.walletName, credentials.password, () => navigate('/wallet/overview'), passphrase)
+    unlockWallet(credentials.walletName, credentials.password, () => navigate('/wallet/overview'), passphrase)
 
     if (passphrase) setPassphrase('')
   }

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -50,7 +50,7 @@ dayjs.extend(relativeTime)
 
 const WalletLayout: FC = ({ children }) => {
   const { t } = useTranslation('App')
-  const { wallet, walletNames, lockWallet, activeWalletName, login, networkStatus } = useGlobalContext()
+  const { wallet, walletNames, lockWallet, activeWalletName, unlockWallet, networkStatus } = useGlobalContext()
   const [isSendModalOpen, setIsSendModalOpen] = useState(false)
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
   const [passphrase, setPassphrase] = useState('')
@@ -78,7 +78,7 @@ const WalletLayout: FC = ({ children }) => {
 
   const onLoginClick = (password: string) => {
     setIsPasswordModalOpen(false)
-    login(
+    unlockWallet(
       switchToWalletName,
       password,
       () => {

--- a/src/pages/WalletManagement/CheckWordsPage.tsx
+++ b/src/pages/WalletManagement/CheckWordsPage.tsx
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { getStorage } from '@alephium/sdk'
 import { motion, PanInfo } from 'framer-motion'
 import { throttle } from 'lodash'
 import { AlertTriangle, ThumbsUp } from 'lucide-react'
@@ -39,8 +38,6 @@ import { useGlobalContext } from '../../contexts/global'
 import { useStepsContext } from '../../contexts/steps'
 import { useWalletContext } from '../../contexts/wallet'
 
-const Storage = getStorage()
-
 interface WordKey {
   word: string
   key: string // Used to build layout and ensure anims are working when duplicates exist
@@ -50,9 +47,8 @@ const CheckWordsPage = () => {
   const { t } = useTranslation('App')
   const { mnemonic, plainWallet, password, walletName } = useWalletContext()
   const { onButtonBack, onButtonNext } = useStepsContext()
-  const { setSnackbarMessage, setWalletNames } = useGlobalContext()
+  const { setSnackbarMessage, saveWallet } = useGlobalContext()
 
-  const { setWallet } = useGlobalContext()
   const splitMnemonic = mnemonic.split(' ')
 
   const wordList = useRef<WordKey[]>(
@@ -184,10 +180,7 @@ const CheckWordsPage = () => {
 
   const createEncryptedWallet = () => {
     if (areWordsValid && plainWallet) {
-      const walletEncrypted = plainWallet.encrypt(password)
-      Storage.save(walletName, walletEncrypted)
-      setWalletNames(Storage.list())
-      setWallet(plainWallet)
+      saveWallet(walletName, plainWallet, password)
       return true
     }
   }

--- a/src/pages/WalletManagement/ImportWordsPage.tsx
+++ b/src/pages/WalletManagement/ImportWordsPage.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { getHumanReadableError, getStorage, walletImport } from '@alephium/sdk'
+import { getHumanReadableError, walletImport } from '@alephium/sdk'
 import Tagify, { BaseTagData, ChangeEventData, TagData } from '@yaireo/tagify'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -36,11 +36,9 @@ import { useStepsContext } from '../../contexts/steps'
 import { useWalletContext } from '../../contexts/wallet'
 import { bip39Words } from '../../utils/bip39'
 
-const Storage = getStorage()
-
 const ImportWordsPage = () => {
   const { t } = useTranslation('App')
-  const { setWallet, setSnackbarMessage, setWalletNames } = useGlobalContext()
+  const { setSnackbarMessage, saveWallet } = useGlobalContext()
   const { password, walletName } = useWalletContext()
   const { onButtonBack, onButtonNext } = useStepsContext()
 
@@ -74,12 +72,7 @@ const ImportWordsPage = () => {
     try {
       const wallet = walletImport(formatedPhrase)
 
-      setWallet(wallet)
-
-      const encryptedWallet = wallet.encrypt(password)
-      Storage.save(walletName, encryptedWallet)
-      setWalletNames(Storage.list())
-
+      saveWallet(walletName, wallet, password)
       onButtonNext()
     } catch (e) {
       setSnackbarMessage({ text: getHumanReadableError(e, t`Error while importing wallet`), type: 'alert' })


### PR DESCRIPTION
@LeeAlephium what do you think of these changes? Instead of exporting `set` methods in the global context, I replaced them with `saveWallet` and `deleteWallet`. It feels cleaner to me that way because we can reuse `saveWallet` instead of basically duplicating its code in the import and create wallet procedure. It also fits well imo next to the other methods of the global context (`lockWallet`, `unlockWallet` - I took the opportunity to rename `login` to `unlockWallet`). This way we also limit the places where we use the `Storage` object from the `getStorage()` SDK method. Lines of code also reduced.