### PR TITLE
nit: Add padding lines

### DIFF
--- a/src/components/OverviewPage/Header.tsx
+++ b/src/components/OverviewPage/Header.tsx
@@ -44,16 +44,19 @@ const OverviewPageHeader = ({ className }: { className?: string }) => {
     (element) => {
       const scrollbar = element?.querySelector('.ScrollbarsCustom-Scroller')
       if (!scrollbar) return
+
       scrollbarRef.current = scrollbar as HTMLDivElement
 
       const onWheel = (event: Event) => {
         const _event = event as WheelEvent
         const delta = _event.deltaY
+
         if (delta > 3 || delta < -3) {
           _event.preventDefault()
           scrollbar.scrollLeft = scrollbar.scrollLeft + delta
         }
       }
+
       scrollbar.addEventListener('wheel', onWheel)
 
       return () => {

--- a/src/components/Scrollbar.tsx
+++ b/src/components/Scrollbar.tsx
@@ -61,6 +61,7 @@ const ScrollbarCustom = (props: ScrollbarCustomProps) => {
   const onWheelY = useCallback(
     (e: WheelEvent) => {
       if (!scrollerElemRef || !scrollerElemRef.current) return
+
       scrollerElemRef.current.scrollTop += e.deltaY
     },
     [scrollerElemRef]
@@ -103,6 +104,7 @@ const ScrollbarCustom = (props: ScrollbarCustomProps) => {
     renderer: ({ elementRef, style, ...restProps }: ElementPropsWithElementRef) => {
       const onElementRef = (element: HTMLDivElement | null) => {
         if (!elementRef) return
+
         scrollerElemRef.current = element
         elementRef(element)
       }

--- a/src/contexts/scroll.tsx
+++ b/src/contexts/scroll.tsx
@@ -28,4 +28,5 @@ const ScrollContext = createContext<ScrollContextType>({
 })
 
 export const ScrollContextProvider = ScrollContext.Provider
+
 export const useScrollContext = () => useContext(ScrollContext)


### PR DESCRIPTION
@LeeAlephium I just added some padding lines based on my preference. It's a nit PR. I think @mvaivre also prefers to have empty lines to separate var declarations, and different statements. How about we use this eslint rule from now on? https://eslint.org/docs/latest/rules/padding-line-between-statements