### PR TITLE
Fixes and improvements on pending tx

### DIFF
--- a/locales/en-US/App.json
+++ b/locales/en-US/App.json
@@ -210,6 +210,7 @@
   "(current)": "(current)",
   "Default address for sending transactions.": "Default address for sending transactions.",
   "Error while fetching data for address {{ hash }}": "Error while fetching data for address {{ hash }}",
+  "Error while fetching pending transactions for address {{ hash }}": "Error while fetching pending transactions for address {{ hash }}",
   "Open in explorer": "Open in explorer",
   "Reduce": "Reduce",
   "Show addresses": "Show addresses",

--- a/locales/fr-FR/App.json
+++ b/locales/fr-FR/App.json
@@ -213,6 +213,7 @@
   "(current)": "(actif)",
   "Default address for sending transactions.": "Adresse par défaut pour effectuer des transactions.",
   "Error while fetching data for address {{ hash }}": "Erreur lors de la récupération des données de l'adresse {{ hash }}",
+  "Error while fetching pending transactions for address {{ hash }}": "Error while fetching pending transactions for address {{ hash }}",
   "Open in explorer": "Ouvrir dans l'explorer",
   "Reduce": "Réduire",
   "Show addresses": "Montrer les adresses",

--- a/locales/fr-FR/App.json
+++ b/locales/fr-FR/App.json
@@ -213,7 +213,7 @@
   "(current)": "(actif)",
   "Default address for sending transactions.": "Adresse par défaut pour effectuer des transactions.",
   "Error while fetching data for address {{ hash }}": "Erreur lors de la récupération des données de l'adresse {{ hash }}",
-  "Error while fetching pending transactions for address {{ hash }}": "Error while fetching pending transactions for address {{ hash }}",
+  "Error while fetching pending transactions for address {{ hash }}": "Erreur durant la récupération de transactions en attente pour l'adresse {{ hash }}",
   "Open in explorer": "Ouvrir dans l'explorer",
   "Reduce": "Réduire",
   "Show addresses": "Montrer les adresses",

--- a/src/components/OverviewPage/TransactionList.tsx
+++ b/src/components/OverviewPage/TransactionList.tsx
@@ -61,14 +61,11 @@ const OverviewPageTransactionList = ({ className, onTransactionClick }: Overview
 
   return (
     <Table isLoading={showSkeletonLoading} className={className} minWidth="500px">
-      {allPendingTxs
-        .slice(0)
-        .reverse()
-        .map(({ data: tx, address }: BelongingToAddress<PendingTx>) => (
-          <TableRow key={tx.txId} blinking role="row" tabIndex={0}>
-            <TransactionalInfo transaction={tx} addressHash={address.hash} />
-          </TableRow>
-        ))}
+      {allPendingTxs.map(({ data: tx, address }: BelongingToAddress<PendingTx>) => (
+        <TableRow key={tx.txId} blinking role="row" tabIndex={0}>
+          <TransactionalInfo transaction={tx} addressHash={address.hash} />
+        </TableRow>
+      ))}
       {allConfirmedTxs.map(({ data: tx, address }: BelongingToAddress<Transaction>) => {
         if (hasOnlyInputsWith((tx as Transaction).inputs ?? [], addresses) && getDirection(tx, address.hash) == 'in')
           return null

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -26,7 +26,7 @@ import styled, { css, useTheme } from 'styled-components'
 
 import { AddressHash, PendingTx, useAddressesContext } from '../contexts/addresses'
 import {
-  calculateTotalTxOutput,
+  calculateAmountSent,
   getDirection,
   hasOnlyOutputsWith,
   isExplorerTransaction,
@@ -76,7 +76,7 @@ const TransactionalInfo = ({ transaction: tx, addressHash, className, hideLeftAd
   if (!_addressHash) return null
 
   if (isExplorerTransaction(tx)) {
-    amount = calculateTotalTxOutput(tx)
+    amount = calculateAmountSent(tx)
     direction = getDirection(tx, _addressHash)
     infoType =
       !hideLeftAddress && direction === 'out' && hasOnlyOutputsWith(tx.outputs ?? [], addresses) ? 'move' : direction

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -164,7 +164,7 @@ const TransactionalInfo = ({ transaction: tx, addressHash, className, hideLeftAd
         </DirectionalAddress>
       </CellAddress>
       <CellAmount aria-hidden="true" color={amountTextColor[infoType]}>
-        {!!amount && (
+        {amount !== undefined && (
           <>
             {lockTime && lockTime > new Date() && <LockStyled unlockAt={lockTime} />}
             <div>

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -32,7 +32,7 @@ import { PartialDeep } from 'type-fest'
 import { TimeInMs } from '../types/numbers'
 import { AddressSettings, loadStoredAddressesMetadataOfWallet, storeAddressMetadataOfWallet } from '../utils/addresses'
 import { NetworkName } from '../utils/settings'
-import { fromUnconfirmedTransactionToPendingTx, TransactionType } from '../utils/transactions'
+import { convertUnconfirmedTxToPendingTx, TransactionType } from '../utils/transactions'
 import { useGlobalContext } from './global'
 
 export type PendingTx = {
@@ -253,7 +253,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
               txs.forEach((tx) => {
                 if (tx.type !== 'Unconfirmed') return
                 if (address.transactions.pending.some((t: PendingTx) => t.txId == tx.hash)) return
-                address.addPendingTransaction(fromUnconfirmedTransactionToPendingTx(tx, address.hash, currentNetwork))
+                address.addPendingTransaction(convertUnconfirmedTxToPendingTx(tx, address.hash, currentNetwork))
               })
             })
           ),

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -439,10 +439,6 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
   useEffect(() => {
     // In case the "to" address of a pending transaction is an address of this wallet, we need to query the API for this
     // one as well
-    const addressesWithPendingSentTxs = addressesOfCurrentNetwork.filter(
-      (address) => address.transactions.pending.filter((pendingTx) => pendingTx.network === currentNetwork).length > 0
-    )
-
     const addressesWithPendingReceivingTxs = addressesOfCurrentNetwork.filter((address) =>
       addressesWithPendingSentTxs.some((addressWithPendingTx) =>
         addressWithPendingTx.transactions.pending.some((pendingTx) => pendingTx.toAddress === address.hash)

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -228,14 +228,20 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
     [wallet, activeWalletName, isPassphraseUsed, setAddress]
   )
 
+  const displayDataFetchingError = useCallback(
+    () =>
+      setSnackbarMessage({
+        text: t`Could not fetch data because the wallet is offline`,
+        type: 'alert',
+        duration: 5000
+      }),
+    [setSnackbarMessage, t]
+  )
+
   const fetchPendingTxs = useCallback(
     async (addresses: Address[] = []) => {
       if (!client) {
-        setSnackbarMessage({
-          text: t`Could not fetch data because the wallet is offline`,
-          type: 'alert',
-          duration: 5000
-        })
+        displayDataFetchingError()
         return
       }
       setIsLoadingData(true)
@@ -266,17 +272,13 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
 
       setIsLoadingData(false)
     },
-    [client, addressesOfCurrentNetwork, setSnackbarMessage, t, currentNetwork]
+    [client, addressesOfCurrentNetwork, displayDataFetchingError, currentNetwork, setSnackbarMessage, t]
   )
 
   const fetchAndStoreAddressesData = useCallback(
     async (addresses: Address[] = [], checkingForPendingTransactions = false) => {
       if (!client) {
-        setSnackbarMessage({
-          text: t`Could not fetch data because the wallet is offline`,
-          type: 'alert',
-          duration: 5000
-        })
+        displayDataFetchingError()
         updateAddressesState(addresses)
         return
       }
@@ -328,7 +330,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       }
       setIsLoadingData(false)
     },
-    [client, addressesOfCurrentNetwork, setSnackbarMessage, updateAddressesState, t]
+    [client, addressesOfCurrentNetwork, displayDataFetchingError, updateAddressesState, setSnackbarMessage, t]
   )
 
   const fetchAddressTransactionsNextPage = async (address: Address) => {

--- a/src/modals/TransactionDetailsModal.tsx
+++ b/src/modals/TransactionDetailsModal.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { addApostrophes, calAmountDelta } from '@alephium/sdk'
+import { addApostrophes } from '@alephium/sdk'
 import { AssetOutput, Transaction } from '@alephium/sdk/dist/api/api-explorer'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -34,6 +34,7 @@ import { Address } from '../contexts/addresses'
 import { useGlobalContext } from '../contexts/global'
 import useAddressLinkHandler from '../hooks/useAddressLinkHandler'
 import { formatDateForDisplay, openInWebBrowser } from '../utils/misc'
+import { calculateAmountSent, getDirection } from '../utils/transactions'
 import { ModalHeader } from './CenteredModal'
 import SideModal from './SideModal'
 
@@ -58,9 +59,8 @@ const TransactionDetailsModal = ({ transaction, address, onClose }: TransactionD
   const theme = useTheme()
   const handleShowAddress = useAddressLinkHandler()
 
-  let amount = calAmountDelta(transaction, address.hash)
-  const isOutgoingTx = amount < 0
-  amount = isOutgoingTx ? amount * -1n : amount
+  const isOutgoingTx = getDirection(transaction, address.hash) === 'out'
+  const amount = calculateAmountSent(transaction)
 
   const outputs = transaction.outputs || []
   let lockTime: Date | undefined = outputs.reduce(

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -32,7 +32,6 @@ import WalletPassphrase from '../components/Inputs/WalletPassphrase'
 import { FloatingPanel, Section } from '../components/PageComponents/PageContainers'
 import PanelTitle from '../components/PageComponents/PanelTitle'
 import Paragraph from '../components/Paragraph'
-import Scrollbar from '../components/Scrollbar'
 import { useGlobalContext } from '../contexts/global'
 import UpdateWalletModal from '../modals/UpdateWalletModal'
 import { deviceBreakPoints } from '../style/globalStyles'
@@ -53,40 +52,38 @@ const HomePage = () => {
   }, [newLatestVersion])
 
   return (
-    <Scrollbar>
-      <HomeContainer initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.8 }}>
-        <AppHeader />
-        <SideBar />
-        <InteractionArea>
-          <FloatingPanel verticalAlign="center" horizontalAlign="center">
-            {!showInitialActions && !hasWallet && (
-              <>
-                <PanelTitle useLayoutId={false}>{t`Welcome!`}</PanelTitle>
-                <InitialActions />
-              </>
-            )}
-            {!showInitialActions && hasWallet && (
-              <>
-                <PanelTitle useLayoutId={false} isSticky={false}>{t`Welcome back!`}</PanelTitle>
-                <Paragraph centered secondary>
-                  {t`Please choose a wallet and enter your password to continue.`}
-                </Paragraph>
-                <Login onLinkClick={displayInitialActions} walletNames={walletNames} />
-              </>
-            )}
-            {showInitialActions && (
-              <>
-                <PanelTitle useLayoutId={false}>{t`New wallet`}</PanelTitle>
-                <InitialActions showLinkToExistingWallets onLinkClick={hideInitialActions} />
-              </>
-            )}
-          </FloatingPanel>
-        </InteractionArea>
-        {isUpdateWalletModalVisible && (
-          <UpdateWalletModal newVersion={newLatestVersion} onClose={() => setUpdateWalletModalVisible(false)} />
-        )}
-      </HomeContainer>
-    </Scrollbar>
+    <HomeContainer initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.8 }}>
+      <AppHeader />
+      <SideBar />
+      <InteractionArea>
+        <FloatingPanel verticalAlign="center" horizontalAlign="center">
+          {!showInitialActions && !hasWallet && (
+            <>
+              <PanelTitle useLayoutId={false}>{t`Welcome!`}</PanelTitle>
+              <InitialActions />
+            </>
+          )}
+          {!showInitialActions && hasWallet && (
+            <>
+              <PanelTitle useLayoutId={false} isSticky={false}>{t`Welcome back!`}</PanelTitle>
+              <Paragraph centered secondary>
+                {t`Please choose a wallet and enter your password to continue.`}
+              </Paragraph>
+              <Login onLinkClick={displayInitialActions} walletNames={walletNames} />
+            </>
+          )}
+          {showInitialActions && (
+            <>
+              <PanelTitle useLayoutId={false}>{t`New wallet`}</PanelTitle>
+              <InitialActions showLinkToExistingWallets onLinkClick={hideInitialActions} />
+            </>
+          )}
+        </FloatingPanel>
+      </InteractionArea>
+      {isUpdateWalletModalVisible && (
+        <UpdateWalletModal newVersion={newLatestVersion} onClose={() => setUpdateWalletModalVisible(false)} />
+      )}
+    </HomeContainer>
   )
 }
 
@@ -181,7 +178,6 @@ export default HomePage
 
 const HomeContainer = styled(motion.main)`
   display: flex;
-  height: 100%;
   flex: 1;
   background-color: ${({ theme }) => theme.bg.secondary};
 

--- a/src/pages/Wallet/WalletLayout.tsx
+++ b/src/pages/Wallet/WalletLayout.tsx
@@ -65,10 +65,6 @@ const WalletLayout: FC = ({ children }) => {
     value: walletName
   }))
 
-  const refreshData = () => {
-    refreshAddressesData()
-  }
-
   const handleWalletNameChange = (option: WalletNameSelectOptions | undefined) => {
     if (option) {
       setSwitchToWalletName(option.value)
@@ -104,7 +100,7 @@ const WalletLayout: FC = ({ children }) => {
           <RefreshButton
             transparent
             squared
-            onClick={refreshData}
+            onClick={refreshAddressesData}
             disabled={isLoadingData}
             aria-label={t`Refresh`}
             data-tip={t`Refresh data`}

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -99,7 +99,7 @@ export const getDirection = (tx: Transaction, address: AddressHash): Transaction
   return amount && amountIsBigInt && amount < 0 ? 'out' : 'in'
 }
 
-export const calculateTotalTxOutput = (tx: Transaction) => {
+export const calculateAmountSent = (tx: Transaction | UnconfirmedTransaction): bigint => {
   const outputs = tx.outputs ?? []
   const inputAddresses = tx.inputs ? uniq(tx.inputs.map((input) => input.address)) : []
 
@@ -117,10 +117,9 @@ export const convertUnconfirmedTxToPendingTx = (
   belongingTo: AddressHash,
   network: NetworkName
 ): PendingTx => {
-  let amount = calculateTotalTxOutput(tx as unknown as Transaction)
-  const amountIsBigInt = typeof amount === 'bigint'
-  const type = amount && amountIsBigInt && amount < 0 ? 'out' : 'in'
-  amount = amount && (type === 'out' ? amount * BigInt(-1) : amount)
+  let amount = calculateAmountSent(tx)
+  const type = amount < 0 ? 'out' : 'in'
+  amount = type === 'out' ? amount * BigInt(-1) : amount
 
   const fromAddress = type === 'out' ? belongingTo : ((tx.inputs ?? [])[0] ?? {}).address
   const toAddress = type === 'in' ? ((tx.outputs ?? [])[0] ?? {}).address : belongingTo

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -119,7 +119,7 @@ export const calculateTotalTxOutput = (tx: Transaction) => {
   return total - change
 }
 
-export const fromUnconfirmedTransactionToPendingTx = (
+export const convertUnconfirmedTxToPendingTx = (
   tx: UnconfirmedTransaction,
   belongingTo: AddressHash,
   network: NetworkName


### PR DESCRIPTION
This PR fixes:
1. The scroll issue in the home page (see https://github.com/alephium/desktop-wallet/pull/377#discussion_r982459318)

This PR improves:
1. The display of consolidation txs. When sending from address X to address X, the tx tables show nothing as value, and the tx details modal shows only the fee as the sent value, which is confusing. 

|before | after |
| ----- | ----- |
| ![image](https://user-images.githubusercontent.com/1579899/192803373-6d674320-f336-4e0b-aa96-67de462d0dd1.png)  | ![image](https://user-images.githubusercontent.com/1579899/192802658-7b4101a3-5cf4-4ea8-ab4e-d0a04e5bd11a.png)|
| ![image](https://user-images.githubusercontent.com/1579899/192803493-05f83483-1ca4-41b0-92b7-7c5ddcf4c247.png) | ![image](https://user-images.githubusercontent.com/1579899/192802819-597d250b-760d-43f5-b761-8b2293b237f8.png) |