### PR TITLE
Clean-up after utils were moved to SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "electron-is-dev": "^2.0.0"
       },
       "devDependencies": {
-        "@alephium/sdk": "0.2.0-rc.0",
+        "@alephium/sdk": "0.2.0",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",
         "@types/jest": "^27.0.2",
@@ -79,9 +79,9 @@
       "dev": true
     },
     "node_modules/@alephium/sdk": {
-      "version": "0.2.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.2.0-rc.0.tgz",
-      "integrity": "sha512-mWSNqOwBUL6TnfUlNOy9ag/vg1xfBmImIiP7Flgk5rO2M924UcrSlWuJcwQ/UmrEVw13kzlB3BsRNdHvHz5DBw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.2.0.tgz",
+      "integrity": "sha512-WI1ebbqhNjWpaWpzQKzu+A1eFMmYW/2XlGqcvC5xpjTr3AjRTKFzFBUFPq61rB3H0ZUJWq06ITj2feljFTKf7g==",
       "dev": true,
       "dependencies": {
         "base-x": "^4.0.0",
@@ -31716,9 +31716,9 @@
       "dev": true
     },
     "@alephium/sdk": {
-      "version": "0.2.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.2.0-rc.0.tgz",
-      "integrity": "sha512-mWSNqOwBUL6TnfUlNOy9ag/vg1xfBmImIiP7Flgk5rO2M924UcrSlWuJcwQ/UmrEVw13kzlB3BsRNdHvHz5DBw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.2.0.tgz",
+      "integrity": "sha512-WI1ebbqhNjWpaWpzQKzu+A1eFMmYW/2XlGqcvC5xpjTr3AjRTKFzFBUFPq61rB3H0ZUJWq06ITj2feljFTKf7g==",
       "dev": true,
       "requires": {
         "base-x": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "electron-is-dev": "^2.0.0"
       },
       "devDependencies": {
-        "@alephium/sdk": "0.1.0",
+        "@alephium/sdk": "0.2.0-rc.0",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.0",
         "@types/jest": "^27.0.2",
@@ -79,9 +79,9 @@
       "dev": true
     },
     "node_modules/@alephium/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-7+BENuSaN5mZG64Uflp0tPDRbKJkQiZsE40o1vYOmLkveGzgkitLTmvn9JZ/ey+oEt8HMWosl2VWqq4z9E/sLg==",
+      "version": "0.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.2.0-rc.0.tgz",
+      "integrity": "sha512-mWSNqOwBUL6TnfUlNOy9ag/vg1xfBmImIiP7Flgk5rO2M924UcrSlWuJcwQ/UmrEVw13kzlB3BsRNdHvHz5DBw==",
       "dev": true,
       "dependencies": {
         "base-x": "^4.0.0",
@@ -31716,9 +31716,9 @@
       "dev": true
     },
     "@alephium/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-7+BENuSaN5mZG64Uflp0tPDRbKJkQiZsE40o1vYOmLkveGzgkitLTmvn9JZ/ey+oEt8HMWosl2VWqq4z9E/sLg==",
+      "version": "0.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.2.0-rc.0.tgz",
+      "integrity": "sha512-mWSNqOwBUL6TnfUlNOy9ag/vg1xfBmImIiP7Flgk5rO2M924UcrSlWuJcwQ/UmrEVw13kzlB3BsRNdHvHz5DBw==",
       "dev": true,
       "requires": {
         "base-x": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "electron-is-dev": "^2.0.0"
   },
   "devDependencies": {
-    "@alephium/sdk": "0.1.0",
+    "@alephium/sdk": "0.2.0-rc.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.0",
     "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "electron-is-dev": "^2.0.0"
   },
   "devDependencies": {
-    "@alephium/sdk": "0.2.0-rc.0",
+    "@alephium/sdk": "0.2.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.0",
     "@types/jest": "^27.0.2",

--- a/src/components/OverviewPage/TransactionList.tsx
+++ b/src/components/OverviewPage/TransactionList.tsx
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { getDirection } from '@alephium/sdk'
 import { Transaction } from '@alephium/sdk/api/explorer'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -26,12 +27,7 @@ import Table, { TableCell, TableCellPlaceholder, TableRow } from '../../componen
 import TransactionalInfo from '../../components/TransactionalInfo'
 import { Address, PendingTx, useAddressesContext } from '../../contexts/addresses'
 import { GENESIS_TIMESTAMP } from '../../utils/constants'
-import {
-  BelongingToAddress,
-  getDirection,
-  getTransactionsForAddresses,
-  hasOnlyInputsWith
-} from '../../utils/transactions'
+import { BelongingToAddress, getTransactionsForAddresses, hasOnlyInputsWith } from '../../utils/transactions'
 
 interface OverviewPageTransactionListProps {
   onTransactionClick: (transaction: Transaction & { address: Address }) => void

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { formatAmountForDisplay } from '@alephium/sdk'
+import { formatAmountForDisplay, isConsolidationTx } from '@alephium/sdk'
 import { Transaction } from '@alephium/sdk/api/explorer'
 import { ArrowRight as ArrowRightIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -26,7 +26,7 @@ import styled, { css } from 'styled-components'
 import { AddressHash, useAddressesContext } from '../contexts/addresses'
 import { useTransactionInfo } from '../hooks/useTransactionInfo'
 import { useTransactionUI } from '../hooks/useTransactionUI'
-import { isConsolidationTx, isPendingTx, TransactionVariant } from '../utils/transactions'
+import { isPendingTx, TransactionVariant } from '../utils/transactions'
 import AddressBadge from './AddressBadge'
 import AddressEllipsed from './AddressEllipsed'
 import Amount from './Amount'

--- a/src/hooks/useTransactionUI.tsx
+++ b/src/hooks/useTransactionUI.tsx
@@ -16,12 +16,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { TransactionInfoType } from '@alephium/sdk'
 import { colord } from 'colord'
 import { ArrowDown, ArrowLeftRight, ArrowUp, CircleEllipsis } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from 'styled-components'
-
-import { TransactionInfoType } from '../utils/transactions'
 
 export const useTransactionUI = (infoType: TransactionInfoType) => {
   const theme = useTheme()

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -16,10 +16,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { calAmountDelta, MIN_UTXO_SET_AMOUNT } from '@alephium/sdk'
-import { AssetOutput } from '@alephium/sdk/api/alephium'
+import { isConsolidationTx, MIN_UTXO_SET_AMOUNT, removeConsolidationChangeAmount } from '@alephium/sdk'
 import { Input, Output, Transaction, UnconfirmedTransaction } from '@alephium/sdk/api/explorer'
-import { uniq } from 'lodash'
 
 import { Address, AddressHash, PendingTx } from '../contexts/addresses'
 import { NetworkName } from './settings'
@@ -35,8 +33,6 @@ export type BelongingToAddress<T extends TransactionVariant> = { data: IsTransac
 export const isAmountWithinRange = (amount: bigint, maxAmount: bigint): boolean =>
   amount >= MIN_UTXO_SET_AMOUNT && amount <= maxAmount
 
-export type TransactionDirection = 'out' | 'in'
-export type TransactionInfoType = TransactionDirection | 'move' | 'pending'
 export type TransactionType = 'consolidation' | 'transfer' | 'sweep'
 export type TransactionStatus = 'pending' | 'confirmed'
 
@@ -75,9 +71,6 @@ export const hasOnlyInputsWith = (inputs: Input[], addresses: Address[]): boolea
 export const hasOnlyOutputsWith = (outputs: Output[], addresses: Address[]): boolean =>
   outputs.every((o) => o?.address && addresses.map((a) => a.hash).indexOf(o.address) >= 0)
 
-export const getDirection = (tx: Transaction, address: AddressHash): TransactionDirection =>
-  calAmountDelta(tx, address) < 0 ? 'out' : 'in'
-
 export const calculateUnconfirmedTxSentAmount = (tx: UnconfirmedTransaction, address: AddressHash): bigint => {
   if (!tx.inputs || !tx.outputs) throw 'Missing transaction details'
 
@@ -92,20 +85,6 @@ export const calculateUnconfirmedTxSentAmount = (tx: UnconfirmedTransaction, add
 
   return totalOutputAmount - totalOutputAmountOfAddress
 }
-
-export const isConsolidationTx = (tx: Transaction | UnconfirmedTransaction): boolean => {
-  const inputAddresses = tx.inputs ? uniq(tx.inputs.map((input) => input.address)) : []
-  const outputAddresses = tx.outputs ? uniq(tx.outputs.map((output) => output.address)) : []
-
-  return inputAddresses.length === 1 && outputAddresses.length === 1 && inputAddresses[0] === outputAddresses[0]
-}
-
-export const removeConsolidationChangeAmount = (totalOutputAmount: bigint, outputs: AssetOutput[] | Output[]) =>
-  outputs.length > 1
-    ? // If there are multiple outputs, the last one must be the change amount (this is a heuristic and not guaranteed)
-      totalOutputAmount - BigInt(outputs[outputs.length - 1].attoAlphAmount)
-    : // otherwise, it's a sweep transaction that consolidates all funds
-      totalOutputAmount
 
 // It can currently only take care of sending transactions.
 // See: https://github.com/alephium/explorer-backend/issues/360


### PR DESCRIPTION
Since many transaction-related utility functions were moved from the desktop wallet to the SDK (see PR https://github.com/alephium/js-sdk/pull/125), a clean-up was needed in the desktop wallet. This PR does just that.

I add the "WIP" prefix until https://github.com/alephium/js-sdk/pull/125 is merged.