### PR TITLE
Use React portals to fix all modals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,6 +100,8 @@ const App = () => {
   )
 }
 
+export default App
+
 const AppContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -111,5 +113,3 @@ const AppContainer = styled.div`
 const BannerSection = styled.div`
   flex-shrink: 0;
 `
-
-export default App

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { colord } from 'colord'
-import { AnimatePresence, motion, useMotionValue, useTransform } from 'framer-motion'
+import { motion, useMotionValue, useTransform } from 'framer-motion'
 import { Eye, EyeOff, WifiOff } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -30,6 +30,7 @@ import { useScrollContext } from '@/contexts/scroll'
 import { useWalletConnectContext } from '@/contexts/walletconnect'
 import { useAppSelector } from '@/hooks/redux'
 import walletConnectIcon from '@/images/wallet-connect-logo.svg'
+import ModalPortal from '@/modals/ModalPortal'
 import WalletConnectModal from '@/modals/WalletConnectModal'
 import { appHeaderHeightPx, walletSidebarWidthPx } from '@/style/globalStyles'
 
@@ -139,11 +140,11 @@ const AppHeader: FC<AppHeader> = ({ children, className }) => {
           </>
         )}
       </motion.header>
-      <AnimatePresence>
+      <ModalPortal>
         {isWalletConnectModalOpen && (
           <WalletConnectModal uri={deepLinkUri} onClose={() => setIsWalletConnectModalOpen(false)} />
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </>
   )
 }

--- a/src/components/Inputs/AddressSelect.tsx
+++ b/src/components/Inputs/AddressSelect.tsx
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence } from 'framer-motion'
 import { MoreVertical } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -31,6 +30,7 @@ import { MoreIcon, SelectContainer } from '@/components/Inputs/Select'
 import { sectionChildrenVariants } from '@/components/PageComponents/PageContainers'
 import { Address } from '@/contexts/addresses'
 import CenteredModal, { ModalFooterButton, ModalFooterButtons } from '@/modals/CenteredModal'
+import ModalPortal from '@/modals/ModalPortal'
 import { sortAddressList } from '@/utils/addresses'
 
 import Option from './Option'
@@ -99,7 +99,7 @@ function AddressSelect({
           {!!address.settings.label && <AddressEllipsed addressHash={address.hash} />}
         </ClickableInput>
       </AddressSelectContainer>
-      <AnimatePresence>
+      <ModalPortal>
         {isAddressSelectModalOpen && (
           <AddressSelectModal
             options={options}
@@ -112,7 +112,7 @@ function AddressSelect({
             }}
           />
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </>
   )
 }

--- a/src/components/Inputs/Select.tsx
+++ b/src/components/Inputs/Select.tsx
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence } from 'framer-motion'
 import { isEqual } from 'lodash'
 import { MoreVertical } from 'lucide-react'
 import { OptionHTMLAttributes, useCallback, useEffect, useState } from 'react'
@@ -26,6 +25,7 @@ import { InputLabel, InputProps } from '@/components/Inputs'
 import InputArea from '@/components/Inputs/InputArea'
 import { sectionChildrenVariants } from '@/components/PageComponents/PageContainers'
 import Popup from '@/components/Popup'
+import ModalPortal from '@/modals/ModalPortal'
 
 import { InputBase } from './Input'
 
@@ -142,7 +142,7 @@ function Select<T extends OptionValue>({
           label={label}
         />
       </SelectContainer>
-      <AnimatePresence>
+      <ModalPortal>
         {showPopup && (
           <SelectOptionsPopup
             options={options}
@@ -153,7 +153,7 @@ function Select<T extends OptionValue>({
             }}
           />
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </>
   )
 }

--- a/src/components/WalletSwitcher.tsx
+++ b/src/components/WalletSwitcher.tsx
@@ -16,11 +16,12 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence } from 'framer-motion'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
+
+import ModalPortal from '@/modals/ModalPortal'
 
 import { useGlobalContext } from '../contexts/global'
 import CenteredModal from '../modals/CenteredModal'
@@ -95,7 +96,7 @@ const WalletSwitcher = () => {
           skipEqualityCheck
         />
       )}
-      <AnimatePresence>
+      <ModalPortal>
         {isPasswordModalOpen && (
           <CenteredModal narrow title={t`Enter password`} onClose={onPasswordModalClose}>
             <PasswordConfirmation
@@ -112,7 +113,7 @@ const WalletSwitcher = () => {
             </PasswordConfirmation>
           </CenteredModal>
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </>
   )
 }

--- a/src/modals/AddressOptionsModal.tsx
+++ b/src/modals/AddressOptionsModal.tsx
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence } from 'framer-motion'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { useTheme } from 'styled-components'
@@ -31,6 +30,7 @@ import { getRandomLabelColor } from '@/utils/colors'
 
 import AddressSweepModal from './AddressSweepModal'
 import CenteredModal, { ModalFooterButton, ModalFooterButtons } from './CenteredModal'
+import ModalPortal from './ModalPortal'
 
 interface AddressOptionsModalProps {
   address: Address
@@ -117,7 +117,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModalProps) => 
           <ModalFooterButton onClick={onGenerateClick}>{t`Save`}</ModalFooterButton>
         </ModalFooterButtons>
       </CenteredModal>
-      <AnimatePresence>
+      <ModalPortal>
         {isAddressSweepModalOpen && (
           <AddressSweepModal
             sweepAddress={address}
@@ -125,7 +125,7 @@ const AddressOptionsModal = ({ address, onClose }: AddressOptionsModalProps) => 
             onSuccessfulSweep={onClose}
           />
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </>
   )
 }

--- a/src/modals/ContactSelectModal.tsx
+++ b/src/modals/ContactSelectModal.tsx
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence } from 'framer-motion'
 import { SearchIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -36,6 +35,7 @@ import { Contact } from '@/types/contacts'
 import { filterContacts } from '@/utils/contacts'
 
 import ContactFormModal from './ContactFormModal'
+import ModalPortal from './ModalPortal'
 
 interface ContactSelectModalProps {
   setContact: (contact: Contact) => void | undefined
@@ -101,9 +101,9 @@ const ContactSelectModal = ({ setContact, onClose }: ContactSelectModalProps) =>
           {t('Select')}
         </ModalFooterButton>
       </ModalFooterButtons>
-      <AnimatePresence>
+      <ModalPortal>
         {isContactFormModalOpen && <ContactFormModal onClose={() => setIsContactFormModalOpen(false)} />}
-      </AnimatePresence>
+      </ModalPortal>
     </CenteredModal>
   )
 }

--- a/src/modals/ModalPortal.tsx
+++ b/src/modals/ModalPortal.tsx
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { AnimatePresence } from 'framer-motion'
+import { createPortal } from 'react-dom'
+
+const ModalPortal: FC = ({ children }) => createPortal(<AnimatePresence>{children}</AnimatePresence>, document.body)
+
+export default ModalPortal

--- a/src/modals/SendModals/AddressSelectTo.tsx
+++ b/src/modals/SendModals/AddressSelectTo.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { Contact as ContactIcon } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -31,6 +31,7 @@ import { selectAllContacts } from '@/store/contactsSlice'
 import { Contact } from '@/types/contacts'
 
 import ContactSelectModal from '../ContactSelectModal'
+import ModalPortal from '../ModalPortal'
 
 interface AddressSelectToProps extends InputProps {
   onContactSelect: (address: string) => void
@@ -87,11 +88,11 @@ const AddressSelectTo = ({ label, onContactSelect, value, ...props }: AddressSel
           </ContactRow>
         )}
       </Input>
-      <AnimatePresence>
+      <ModalPortal>
         {isAddressSelectModalOpen && (
           <ContactSelectModal setContact={handleContactSelect} onClose={() => setIsAddressSelectModalOpen(false)} />
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </>
   )
 }

--- a/src/modals/SendModals/SendModal.tsx
+++ b/src/modals/SendModals/SendModal.tsx
@@ -18,7 +18,6 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { APIError, getHumanReadableError } from '@alephium/sdk'
 import { SignResult, SweepAddressTransaction } from '@alephium/sdk/api/alephium'
-import { AnimatePresence } from 'framer-motion'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from 'styled-components'
@@ -33,6 +32,8 @@ import CenteredModal, { ModalFooterButton, ModalFooterButtons } from '@/modals/C
 import ConsolidateUTXOsModal from '@/modals/ConsolidateUTXOsModal'
 import { TxContext, UnsignedTx } from '@/types/transactions'
 import { extractErrorMsg } from '@/utils/misc'
+
+import ModalPortal from '../ModalPortal'
 
 type Step = 'build-tx' | 'info-check' | 'password-check'
 
@@ -238,7 +239,7 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
           onCorrectPasswordEntered={handleSendExtended}
         />
       )}
-      <AnimatePresence>
+      <ModalPortal>
         {isConsolidateUTXOsModalVisible && (
           <ConsolidateUTXOsModal
             onClose={() => setIsConsolidateUTXOsModalVisible(false)}
@@ -246,7 +247,7 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
             fee={fees}
           />
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </CenteredModal>
   )
 }

--- a/src/modals/SettingsModal/GeneralSettingsSection.tsx
+++ b/src/modals/SettingsModal/GeneralSettingsSection.tsx
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence } from 'framer-motion'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -32,6 +31,8 @@ import useSwitchTheme from '@/hooks/useSwitchTheme'
 import CenteredModal from '@/modals/CenteredModal'
 import { Language, ThemeType } from '@/types/settings'
 import { loadSettings } from '@/utils/settings'
+
+import ModalPortal from '../ModalPortal'
 
 const languageOptions = [
   { label: 'English', value: 'en-US' as Language },
@@ -150,7 +151,7 @@ const GeneralSettingsSection = () => {
           />
         }
       />
-      <AnimatePresence>
+      <ModalPortal>
         {isPasswordModelOpen && (
           <CenteredModal title={t`Password`} onClose={() => setIsPasswordModalOpen(false)} focusMode narrow>
             <PasswordConfirmation
@@ -160,7 +161,7 @@ const GeneralSettingsSection = () => {
             />
           </CenteredModal>
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </>
   )
 }

--- a/src/pages/UnlockedWallet/AddressDetailsPage.tsx
+++ b/src/pages/UnlockedWallet/AddressDetailsPage.tsx
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Transaction } from '@alephium/sdk/api/explorer'
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { ArrowLeft, Settings as SettingsIcon } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -43,6 +43,7 @@ import TransactionalInfo from '@/components/TransactionalInfo'
 import { AddressHash, useAddressesContext } from '@/contexts/addresses'
 import { useAppSelector } from '@/hooks/redux'
 import AddressOptionsModal from '@/modals/AddressOptionsModal'
+import ModalPortal from '@/modals/ModalPortal'
 import TransactionDetailsModal from '@/modals/TransactionDetailsModal'
 
 const AddressDetailsPage = () => {
@@ -179,12 +180,10 @@ const AddressDetailsPage = () => {
           </TableRow>
         )}
       </Table>
-      <AnimatePresence>
+      <ModalPortal>
         {isAddressOptionsModalOpen && (
           <AddressOptionsModal address={address} onClose={() => setIsAddressOptionsModalOpen(false)} />
         )}
-      </AnimatePresence>
-      <AnimatePresence>
         {selectedTransaction && (
           <TransactionDetailsModal
             address={address}
@@ -192,7 +191,7 @@ const AddressDetailsPage = () => {
             onClose={() => setSelectedTransaction(undefined)}
           />
         )}
-      </AnimatePresence>
+      </ModalPortal>
       <Tooltip />
     </motion.div>
   )

--- a/src/pages/UnlockedWallet/AddressesPage/AddressesTabContent.tsx
+++ b/src/pages/UnlockedWallet/AddressesPage/AddressesTabContent.tsx
@@ -16,13 +16,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence } from 'framer-motion'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import Toggle from '@/components/Inputs/Toggle'
 import { useAddressesContext } from '@/contexts/addresses'
+import ModalPortal from '@/modals/ModalPortal'
 import NewAddressModal from '@/modals/NewAddressModal'
 import { sortAddressList } from '@/utils/addresses'
 
@@ -82,7 +82,7 @@ const AddressesTabContent = () => {
         <AddressCard hash={address.hash} key={address.hash} />
       ))}
 
-      <AnimatePresence>
+      <ModalPortal>
         {isGenerateNewAddressModalOpen && (
           <NewAddressModal
             singleAddress
@@ -90,7 +90,7 @@ const AddressesTabContent = () => {
             onClose={() => setIsGenerateNewAddressModalOpen(false)}
           />
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </TabContent>
   )
 }

--- a/src/pages/UnlockedWallet/AddressesPage/ContactsTabContent.tsx
+++ b/src/pages/UnlockedWallet/AddressesPage/ContactsTabContent.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { ArrowUp, Pencil } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -29,6 +29,7 @@ import Card from '@/components/Card'
 import Truncate from '@/components/Truncate'
 import { useAppSelector } from '@/hooks/redux'
 import ContactFormModal from '@/modals/ContactFormModal'
+import ModalPortal from '@/modals/ModalPortal'
 import SendModalTransfer from '@/modals/SendModals/SendModalTransfer'
 import { selectAllContacts } from '@/store/contactsSlice'
 import { Contact } from '@/types/contacts'
@@ -98,12 +99,12 @@ const ContactsTabContent = () => {
             </ButtonsRow>
           </Card>
         ))}
-        <AnimatePresence>
+        <ModalPortal>
           {isContactFormModalOpen && <ContactFormModal contact={selectedContact} onClose={closeContactFormModal} />}
           {isSendModalOpen && (
             <SendModalTransfer initialTxData={{ toAddress: selectedContact?.address }} onClose={closeSendModal} />
           )}
-        </AnimatePresence>
+        </ModalPortal>
       </TabContent>
     </motion.div>
   )

--- a/src/pages/UnlockedWallet/AddressesPage/index.tsx
+++ b/src/pages/UnlockedWallet/AddressesPage/index.tsx
@@ -33,6 +33,7 @@ import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import useAddressDiscovery from '@/hooks/useAddressDiscovery'
 import AddressSweepModal from '@/modals/AddressSweepModal'
 import BottomModal from '@/modals/BottomModal'
+import ModalPortal from '@/modals/ModalPortal'
 import NewAddressModal from '@/modals/NewAddressModal'
 import { addressesPageInfoMessageClosed } from '@/store/appSlice'
 import { appHeaderHeightPx, walletSidebarWidthPx } from '@/style/globalStyles'
@@ -164,7 +165,7 @@ const AddressesPage = () => {
           </AdvancedOperationsHeader>
         </AdvancedOperationsPanel>
       )}
-      <AnimatePresence>
+      <ModalPortal>
         {isConsolidationModalOpen && <AddressSweepModal onClose={() => setIsConsolidationModalOpen(false)} />}
         {isAddressesGenerationModalOpen && (
           <NewAddressModal
@@ -172,7 +173,7 @@ const AddressesPage = () => {
             onClose={() => setIsAddressesGenerationModalOpen(false)}
           />
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </ScreenHeight>
   )
 }

--- a/src/pages/UnlockedWallet/OverviewPage/index.tsx
+++ b/src/pages/UnlockedWallet/OverviewPage/index.tsx
@@ -17,13 +17,14 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Transaction } from '@alephium/sdk/api/explorer'
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { fadeIn } from '@/animations'
 import { PageH2 } from '@/components/PageComponents/PageHeadings'
 import { Address } from '@/contexts/addresses'
+import ModalPortal from '@/modals/ModalPortal'
 import TransactionDetailsModal from '@/modals/TransactionDetailsModal'
 
 import Header from './Header'
@@ -38,7 +39,8 @@ const OverviewPage = () => {
       <Header />
       <PageH2>{t`Transaction history`}</PageH2>
       <TransactionList onTransactionClick={setSelectedTransaction} />
-      <AnimatePresence>
+
+      <ModalPortal>
         {selectedTransaction && (
           <TransactionDetailsModal
             address={selectedTransaction.address}
@@ -46,7 +48,7 @@ const OverviewPage = () => {
             onClose={() => setSelectedTransaction(undefined)}
           />
         )}
-      </AnimatePresence>
+      </ModalPortal>
     </motion.div>
   )
 }

--- a/src/pages/UnlockedWallet/UnlockedWalletLayout.tsx
+++ b/src/pages/UnlockedWallet/UnlockedWalletLayout.tsx
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { Album, ArrowLeftRight, FileCode, Layers, RefreshCw, Settings, TerminalSquare } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -34,6 +34,7 @@ import Spinner from '@/components/Spinner'
 import { useAddressesContext } from '@/contexts/addresses'
 import { useGlobalContext } from '@/contexts/global'
 import { useSendModalContext } from '@/contexts/sendModal'
+import ModalPortal from '@/modals/ModalPortal'
 import NotificationsModal from '@/modals/NotificationsModal'
 import SendModalDeployContract from '@/modals/SendModals/SendModalDeployContract'
 import SendModalScript from '@/modals/SendModals/SendModalScript'
@@ -122,13 +123,13 @@ const UnlockedWalletLayout: FC<UnlockedWalletLayoutProps> = ({ children, classNa
           </AppHeader>
         </Scrollbar>
       </motion.div>
-      <AnimatePresence>
+      <ModalPortal>
         {isSendModalOpen && txType === TxType.TRANSFER && <SendModalTransfer />}
         {isSendModalOpen && txType === TxType.DEPLOY_CONTRACT && <SendModalDeployContract />}
         {isSendModalOpen && txType === TxType.SCRIPT && <SendModalScript />}
         {isSettingsModalOpen && <SettingsModal onClose={() => setIsSettingsModalOpen(false)} />}
         {isNotificationsModalOpen && <NotificationsModal onClose={() => setIsNotificationsModalOpen(false)} />}
-      </AnimatePresence>
+      </ModalPortal>
     </>
   )
 }


### PR DESCRIPTION
This is a very simple PR that makes use of React Portals to place the modals always at the bottom of the DOM to avoid stacking issues. It will be very useful in the upcoming layout changes of stacked modals. It's a very clean solution imo!