### PR TITLE
Fix snapcraft action, add checksums, update network presets

### DIFF
--- a/.afterAllArtifactBuild.js
+++ b/.afterAllArtifactBuild.js
@@ -1,0 +1,49 @@
+// Copyright 2018 - 2022 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+
+function getFileChecksum(path) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256')
+
+    fs.createReadStream(path)
+      .on('error', reject)
+      .on('data', (chunk) => hash.update(chunk))
+      .on('close', () => resolve(hash.digest('hex')))
+  })
+}
+
+exports.default = async function ({ artifactPaths }) {
+  const checksums = []
+
+  for (let i = 0; i < artifactPaths.length; i++) {
+    const artifactPath = artifactPaths[i]
+
+    if (!artifactPath.endsWith('.blockmap') && !artifactPath.endsWith('.snap') && !artifactPath.endsWith('.zip')) {
+      const checksumFilePath = `${artifactPath}.checksum`
+      const checksum = await getFileChecksum(artifactPath)
+
+      fs.writeFileSync(checksumFilePath, `${checksum}  ${path.parse(artifactPath).base}`)
+
+      checksums.push(checksumFilePath)
+    }
+  }
+
+  return checksums
+}

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -36,6 +36,10 @@ jobs:
           echo "args=$args" >> $GITHUB_OUTPUT
         shell: bash
 
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v1
+        if: startsWith(matrix.os, 'ubuntu')
+
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -52,9 +56,4 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.apple_id_password }}
           APPLEID: ${{ secrets.apple_id }}
           APPLEIDPASS: ${{ secrets.apple_id_password }}
-
-      - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v1
-        if: startsWith(matrix.os, 'ubuntu')
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapcraft_token }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   },
   "build": {
     "appId": "org.alephium.alephium-wallet",
+    "productName": "Alephium",
     "files": [
       "build/**/*",
       "public/electron.js",
@@ -122,16 +123,19 @@
         "snap"
       ]
     },
-    "productName": "Alephium",
+    "win": {
+      "artifactName": "${productName}-${version}.${ext}"
+    },
+    "mac": {
+      "hardenedRuntime": true,
+      "entitlements": "./node_modules/electron-builder-notarize/entitlements.mac.inherit.plist"
+    },
     "directories": {
       "buildResources": "assets"
     },
     "afterPack": ".afterPack.js",
-    "afterSign": "electron-builder-notarize",
-    "mac": {
-      "hardenedRuntime": true,
-      "entitlements": "./node_modules/electron-builder-notarize/entitlements.mac.inherit.plist"
-    }
+    "afterAllArtifactBuild": ".afterAllArtifactBuild.js",
+    "afterSign": "electron-builder-notarize"
   },
   "engines": {
     "node": ">=16",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     ],
     "linux": {
       "category": "Finance",
-      "executableName": "alephium",
       "target": [
         "AppImage",
         "deb",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
       "executableName": "alephium",
       "target": [
         "AppImage",
-        "deb"
+        "deb",
+        "snap"
       ]
     },
     "productName": "Alephium",

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -95,8 +95,8 @@ describe('Settings migration', () => {
     for (const settings of mainnetSettings) {
       localStorage.setItem('settings', JSON.stringify(settings))
       const migratedSettings = migrateDeprecatedSettings()
-      expect(migratedSettings.network.nodeHost).toBe('https://wallet-v15.mainnet.alephium.org')
-      expect(migratedSettings.network.explorerApiHost).toBe('https://backend-v110.mainnet.alephium.org')
+      expect(migratedSettings.network.nodeHost).toBe('https://wallet-v16.mainnet.alephium.org')
+      expect(migratedSettings.network.explorerApiHost).toBe('https://backend-v112.mainnet.alephium.org')
       expect(migratedSettings.network.explorerUrl).toBe('https://explorer.alephium.org')
       expect(migratedSettings.network.networkId).toBe(0)
     }
@@ -123,8 +123,8 @@ describe('Settings migration', () => {
     for (const settings of testnetSettings) {
       localStorage.setItem('settings', JSON.stringify(settings))
       const migratedSettings = migrateDeprecatedSettings()
-      expect(migratedSettings.network.nodeHost).toBe('https://wallet-v15.testnet.alephium.org')
-      expect(migratedSettings.network.explorerApiHost).toBe('https://backend-v110.testnet.alephium.org')
+      expect(migratedSettings.network.nodeHost).toBe('https://wallet-v16.testnet.alephium.org')
+      expect(migratedSettings.network.explorerApiHost).toBe('https://backend-v112.testnet.alephium.org')
       expect(migratedSettings.network.explorerUrl).toBe('https://explorer.testnet.alephium.org')
       expect(migratedSettings.network.networkId).toBe(1)
     }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -46,14 +46,14 @@ type DeprecatedNetworkSettings = Settings['network']
 export const networkEndpoints: Record<Exclude<NetworkName, 'custom'>, Settings['network']> = {
   mainnet: {
     networkId: 0,
-    nodeHost: 'https://wallet-v15.mainnet.alephium.org',
-    explorerApiHost: 'https://backend-v110.mainnet.alephium.org',
+    nodeHost: 'https://wallet-v16.mainnet.alephium.org',
+    explorerApiHost: 'https://backend-v112.mainnet.alephium.org',
     explorerUrl: 'https://explorer.alephium.org'
   },
   testnet: {
     networkId: 1,
-    nodeHost: 'https://wallet-v15.testnet.alephium.org',
-    explorerApiHost: 'https://backend-v110.testnet.alephium.org',
+    nodeHost: 'https://wallet-v16.testnet.alephium.org',
+    explorerApiHost: 'https://backend-v112.testnet.alephium.org',
     explorerUrl: 'https://explorer.testnet.alephium.org'
   },
   localhost: {
@@ -119,12 +119,12 @@ export const migrateDeprecatedSettings = (): Settings => {
     settings.network.explorerApiHost === 'https://mainnet-backend.alephium.org' ||
     settings.network.explorerApiHost === 'https://backend-v18.mainnet.alephium.org'
   ) {
-    migratedSettings.network.explorerApiHost = 'https://backend-v110.mainnet.alephium.org'
+    migratedSettings.network.explorerApiHost = 'https://backend-v112.mainnet.alephium.org'
   } else if (
     settings.network.explorerApiHost === 'https://testnet-backend.alephium.org' ||
     settings.network.explorerApiHost === 'https://backend-v18.testnet.alephium.org'
   ) {
-    migratedSettings.network.explorerApiHost = 'https://backend-v110.testnet.alephium.org'
+    migratedSettings.network.explorerApiHost = 'https://backend-v112.testnet.alephium.org'
   }
 
   if (settings.network.explorerUrl === 'https://explorer-v18.mainnet.alephium.org') {
@@ -140,12 +140,12 @@ export const migrateDeprecatedSettings = (): Settings => {
     settings.network.nodeHost === 'https://mainnet-wallet.alephium.org' ||
     settings.network.nodeHost === 'https://wallet-v18.mainnet.alephium.org'
   ) {
-    migratedSettings.network.nodeHost = 'https://wallet-v15.mainnet.alephium.org'
+    migratedSettings.network.nodeHost = 'https://wallet-v16.mainnet.alephium.org'
   } else if (
     settings.network.nodeHost === 'https://testnet-wallet.alephium.org' ||
     settings.network.nodeHost === 'https://wallet-v18.testnet.alephium.org'
   ) {
-    migratedSettings.network.nodeHost = 'https://wallet-v15.testnet.alephium.org'
+    migratedSettings.network.nodeHost = 'https://wallet-v16.testnet.alephium.org'
   }
 
   const newSettings = merge({}, defaultSettings, migratedSettings)


### PR DESCRIPTION
1. Fixes Linux Snapcraft action (thanks @killerwhile ❤️)
2. Adds checksum files for `.exe`, `.deb`, `.dmg`, and `.AppImage` (like our old release workflow had, see #494)
3. Updates mainnet & testnet network presets to point to:
   - `https://wallet-v16/.[mainnet|testnet].alephium.org`
   - `https://backend-v112/.[mainnet|testnet].alephium.org`

Closes #141 

Closes #412 

Closes #494