### PR TITLE
Create Redux slices: addresses & confirmed transactions

### DIFF
--- a/src/api/addresses.ts
+++ b/src/api/addresses.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import client from '@/api/client'
+import { AddressHash } from '@/types/addresses'
+
+export const fetchAddressesData = async (addressHashes: AddressHash[]) => {
+  const results = []
+
+  for (const addressHash of addressHashes) {
+    console.log('⬇️ Fetching address details: ', addressHash)
+    const { data: details } = await client.explorerClient.getAddressDetails(addressHash)
+
+    console.log('⬇️ Fetching 1st page of address confirmed transactions: ', addressHash)
+    const { data: transactions } = await client.explorerClient.getAddressTransactions(addressHash, 1)
+
+    console.log('⬇️ Fetching address tokens: ', addressHash)
+    const { data: tokenIds } = await client.explorerClient.addresses.getAddressesAddressTokens(addressHash)
+
+    const tokens = await Promise.all(
+      tokenIds.map((id) =>
+        client.explorerClient.addresses.getAddressesAddressTokensTokenIdBalance(addressHash, id).then(({ data }) => ({
+          id,
+          balances: data
+        }))
+      )
+    )
+
+    results.push({
+      hash: addressHash,
+      details,
+      transactions,
+      tokens
+    })
+  }
+
+  return results
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { CliqueClient, ExplorerClient } from '@alephium/sdk'
+import { NodeProvider as Web3Client } from '@alephium/web3'
+
+import { defaultSettings } from '@/persistent-storage/settings'
+import { NetworkSettings } from '@/types/settings'
+
+export class Client {
+  cliqueClient: CliqueClient
+  explorerClient: ExplorerClient
+  web3Client: Web3Client
+
+  constructor() {
+    const { nodeHost, explorerApiHost } = defaultSettings.network
+
+    this.cliqueClient = new CliqueClient({ baseUrl: nodeHost })
+    this.explorerClient = new ExplorerClient({ baseUrl: explorerApiHost })
+    this.web3Client = new Web3Client(nodeHost)
+  }
+
+  async init(
+    nodeHost: NetworkSettings['nodeHost'],
+    explorerApiHost: NetworkSettings['explorerApiHost'],
+    isMultiNodesClique = false
+  ) {
+    this.cliqueClient = new CliqueClient({ baseUrl: nodeHost })
+    this.explorerClient = new ExplorerClient({ baseUrl: explorerApiHost })
+    this.web3Client = new Web3Client(nodeHost)
+
+    await this.cliqueClient.init(isMultiNodesClique)
+  }
+}
+
+const client = new Client()
+
+export default client

--- a/src/components/AddressEllipsed.tsx
+++ b/src/components/AddressEllipsed.tsx
@@ -19,7 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { HTMLAttributes } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { AddressHash } from '@/contexts/addresses'
+import { AddressHash } from '@/types/addresses'
 
 import ClipboardButton from './Buttons/ClipboardButton'
 import Ellipsed from './Ellipsed'

--- a/src/components/IOList.tsx
+++ b/src/components/IOList.tsx
@@ -21,8 +21,9 @@ import _ from 'lodash'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import { AddressHash, useAddressesContext } from '@/contexts/addresses'
+import { useAddressesContext } from '@/contexts/addresses'
 import useAddressLinkHandler from '@/hooks/useAddressLinkHandler'
+import { AddressHash } from '@/types/addresses'
 import { GENESIS_TIMESTAMP } from '@/utils/constants'
 
 import ActionLink from './ActionLink'

--- a/src/components/Inputs/AddressSelect.tsx
+++ b/src/components/Inputs/AddressSelect.tsx
@@ -31,8 +31,8 @@ import { sectionChildrenVariants } from '@/components/PageComponents/PageContain
 import { Address } from '@/contexts/addresses'
 import CenteredModal, { ModalFooterButton, ModalFooterButtons } from '@/modals/CenteredModal'
 import ModalPortal from '@/modals/ModalPortal'
-import { sortAddressList } from '@/utils/addresses'
 
+// import { sortAddressList } from '@/utils/addresses'
 import Option from './Option'
 
 interface AddressSelectProps {
@@ -148,7 +148,8 @@ const AddressSelectModal = ({
     <CenteredModal title={t`Addresses`} onClose={onClose}>
       <Description>{title}</Description>
       <div>
-        {sortAddressList(displayedOptions).map((address) => (
+        {/* TODO: Use sortAddressList(displayedOptions) when dependency from contexts/addresses has been removed */}
+        {displayedOptions.map((address) => (
           <Option
             key={address.hash}
             onSelect={() => setSelectedAddress(address)}

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -43,7 +43,7 @@ const token = 'alph'
 interface TransactionalInfoProps {
   transaction: TransactionVariant
   addressHash?: AddressHash
-  isDisplayedInAddressDetailsPage?: boolean
+  showInternalInflows?: boolean
   className?: string
 }
 
@@ -51,12 +51,12 @@ const TransactionalInfo = ({
   transaction: tx,
   addressHash: addressHashProp,
   className,
-  isDisplayedInAddressDetailsPage
+  showInternalInflows
 }: TransactionalInfoProps) => {
   const { addressHash: addressHashParam = '' } = useParams<{ addressHash: AddressHash }>()
   const addressHash = addressHashProp ?? addressHashParam
   const { getAddress } = useAddressesContext()
-  const { amount, direction, outputs, lockTime, infoType } = useTransactionInfo(tx, addressHash)
+  const { amount, direction, outputs, lockTime, infoType } = useTransactionInfo(tx, addressHash, showInternalInflows)
   const { label, amountTextColor, amountSign: sign, Icon, iconColor, iconBgColor } = useTransactionUI(infoType)
 
   const { t } = useTranslation()
@@ -78,7 +78,7 @@ const TransactionalInfo = ({
   }
 
   const amountSign =
-    isDisplayedInAddressDetailsPage && infoType === 'move' && !isPendingTx(tx) && !isConsolidationTx(tx) ? '- ' : sign
+    showInternalInflows && infoType === 'move' && !isPendingTx(tx) && !isConsolidationTx(tx) ? '- ' : sign
 
   return (
     <div className={className}>
@@ -97,7 +97,7 @@ const TransactionalInfo = ({
       <CellToken>
         <TokenStyled type={token} disableA11y />
       </CellToken>
-      {!isDisplayedInAddressDetailsPage && (
+      {!showInternalInflows && (
         <CellAddress alignRight>
           <HiddenLabel text={t`from`} />
           {direction === 'out' && (
@@ -119,7 +119,7 @@ const TransactionalInfo = ({
       )}
       <CellDirection>
         <HiddenLabel text={t`to`} />
-        {!isDisplayedInAddressDetailsPage ? (
+        {!showInternalInflows ? (
           <ArrowRightIcon size={16} strokeWidth={3} />
         ) : (
           <DirectionText>{direction === 'out' ? t`to` : t`from`}</DirectionText>
@@ -127,10 +127,10 @@ const TransactionalInfo = ({
       </CellDirection>
       <CellAddress>
         <DirectionalAddress>
-          {direction === 'in' && !isDisplayedInAddressDetailsPage && (
+          {direction === 'in' && !showInternalInflows && (
             <AddressBadgeStyled address={address} truncate showHashWhenNoLabel withBorders disableA11y />
           )}
-          {((direction === 'in' && isDisplayedInAddressDetailsPage) || direction === 'out') &&
+          {((direction === 'in' && showInternalInflows) || direction === 'out') &&
             (pendingToAddressComponent || (
               <IOList
                 currentAddress={addressHash}

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -23,9 +23,10 @@ import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 
-import { AddressHash, useAddressesContext } from '@/contexts/addresses'
+import { useAddressesContext } from '@/contexts/addresses'
 import { useTransactionInfo } from '@/hooks/useTransactionInfo'
 import { useTransactionUI } from '@/hooks/useTransactionUI'
+import { AddressHash } from '@/types/addresses'
 import { isPendingTx, TransactionVariant } from '@/utils/transactions'
 
 import AddressBadge from './AddressBadge'

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -118,7 +118,6 @@ export interface AddressesContextProps {
   saveNewAddress: (address: Address, mnemonic?: string, walletName?: string) => void
   updateAddressSettings: (address: Address, settings: AddressSettings) => void
   refreshAddressesData: () => void
-  fetchAddressTransactionsNextPage: (address: Address) => void
   generateOneAddressPerGroup: (labelPrefix?: string, color?: string, skipGroups?: number[]) => void
   isLoadingData: boolean
 }
@@ -131,7 +130,6 @@ export const initialAddressesContext: AddressesContextProps = {
   saveNewAddress: () => null,
   updateAddressSettings: () => null,
   refreshAddressesData: () => null,
-  fetchAddressTransactionsNextPage: () => null,
   generateOneAddressPerGroup: () => null,
   isLoadingData: false
 }
@@ -332,13 +330,6 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
     ]
   )
 
-  const fetchAddressTransactionsNextPage = async (address: Address) => {
-    if (!client || network.status === 'offline') return
-    setIsLoadingData(true)
-    await client.fetchAddressConfirmedTransactionsNextPage(address)
-    setIsLoadingData(false)
-  }
-
   const saveNewAddress = useCallback(
     // TODO: Remove need for walletName and mnemonic once addresses in Redux
     (newAddress: Address, mnemonic?: string, walletName?: string) => {
@@ -425,7 +416,7 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
 
         deriveAddressesFromIndexesWorker.onmessage = async ({ data }: { data: AddressKeyPair[] }) => {
           const addressesToFetchData = data.map(({ hash, publicKey, privateKey, index }) => {
-            const metadata = addressesMetadata.find((metadata) => metadata.index === index)
+            const metadata = addressesMetadata.find((metadata) => metadata.index === index) as AddressMetadata
 
             return new Address(hash, publicKey, privateKey, index, {
               isMain: metadata?.isMain || false,
@@ -522,7 +513,6 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
           saveNewAddress,
           updateAddressSettings,
           refreshAddressesData,
-          fetchAddressTransactionsNextPage,
           generateOneAddressPerGroup,
           isLoadingData: isLoadingData || addressesWithPendingSentTxs.length > 0
         },

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -26,7 +26,7 @@ import { PartialDeep } from 'type-fest'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import AddressMetadataStorage from '@/persistent-storage/address-metadata'
 import { addressesGenerated, addressGenerationStarted } from '@/store/actions'
-import { AddressMetadata, AddressSettings } from '@/types/addresses'
+import { AddressHash, AddressMetadata, AddressSettings } from '@/types/addresses'
 import { NetworkName } from '@/types/network'
 import { TimeInMs } from '@/types/numbers'
 import { PendingTx } from '@/types/transactions'
@@ -41,8 +41,6 @@ const deriveAddressesFromIndexesWorker = new Worker(
 const deriveAddressesInGroupsWorker = new Worker(new URL('../workers/deriveAddressesInGroups.ts', import.meta.url), {
   type: 'module'
 })
-
-export type AddressHash = string
 
 export class Address {
   readonly hash: AddressHash

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -30,6 +30,7 @@ import { AddressHash, AddressMetadata, AddressSettings } from '@/types/addresses
 import { NetworkName } from '@/types/network'
 import { TimeInMs } from '@/types/numbers'
 import { PendingTx } from '@/types/transactions'
+import { getRandomLabelColor } from '@/utils/colors'
 import { convertUnconfirmedTxToPendingTx } from '@/utils/transactions'
 
 import { useGlobalContext } from './global'
@@ -198,14 +199,18 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       if (!activeWallet.name) throw new Error('Could not update address settings, wallet name not found')
 
       if (!activeWallet.isPassphraseUsed)
-        AddressMetadataStorage.store(
-          {
+        AddressMetadataStorage.store({
+          dataKey: {
             mnemonic: activeWallet.mnemonic,
             walletName: activeWallet.name
           },
-          address.index,
-          settings
-        )
+          index: address.index,
+          settings: {
+            ...settings,
+            isDefault: settings.isMain,
+            color: settings.color ?? getRandomLabelColor()
+          }
+        })
       address.settings = settings
       setAddress(address)
     },
@@ -340,14 +345,18 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       if (!_walletName) throw new Error('Could not save new address, wallet name not found')
 
       if (!activeWallet.isPassphraseUsed)
-        AddressMetadataStorage.store(
-          {
+        AddressMetadataStorage.store({
+          dataKey: {
             mnemonic: _mnemonic,
             walletName: _walletName
           },
-          newAddress.index,
-          newAddress.settings
-        )
+          index: newAddress.index,
+          settings: {
+            ...newAddress.settings,
+            isDefault: newAddress.settings.isMain,
+            color: newAddress.settings.color ?? getRandomLabelColor()
+          }
+        })
       setAddress(newAddress)
       fetchAndStoreAddressesData([newAddress])
       fetchPendingTxs([newAddress])

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -113,6 +113,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
 
   useIdleForTooLong(() => dispatch(walletLocked()), (settings.walletLockTimeInMinutes || 0) * 60 * 1000)
 
+  // TODO: Delete when @/util/api-clients becomes obsolete in favor of @/api/client.ts
   const initializeClient = useCallback(async () => {
     if (network.status !== 'offline') dispatch(appLoadingToggled(true))
 
@@ -136,24 +137,16 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
     dispatch(appLoadingToggled(false))
   }, [dispatch, network.name, network.settings, network.status, t])
 
+  // TODO: Delete when @/util/api-clients becomes obsolete in favor of @/api/client.ts
   useEffect(() => {
     if (network.status === 'connecting') {
       initializeClient()
     }
   }, [initializeClient, network.status])
 
+  // TODO: Delete when @/util/api-clients becomes obsolete in favor of @/api/client.ts
   const shouldInitialize = network.status === 'offline'
   useInterval(initializeClient, 2000, !shouldInitialize)
-
-  useEffect(() => {
-    if (network.status === 'offline') {
-      setSnackbarMessage({
-        text: t('Could not connect to the {{ currentNetwork }} network.', { currentNetwork: network.name }),
-        type: 'alert',
-        duration: 5000
-      })
-    }
-  }, [network.name, network.status, t])
 
   useEffect(() => {
     const shouldListenToOSThemeChanges = settings.theme === 'system'

--- a/src/hooks/useAddressLinkHandler.tsx
+++ b/src/hooks/useAddressLinkHandler.tsx
@@ -19,7 +19,8 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { AddressHash, useAddressesContext } from '@/contexts/addresses'
+import { useAddressesContext } from '@/contexts/addresses'
+import { AddressHash } from '@/types/addresses'
 import { openInWebBrowser } from '@/utils/misc'
 
 import { useAppSelector } from './redux'

--- a/src/hooks/useTransactionInfo.tsx
+++ b/src/hooks/useTransactionInfo.tsx
@@ -29,7 +29,7 @@ import { useAddressesContext } from '@/contexts/addresses'
 import { AddressHash } from '@/types/addresses'
 import { hasOnlyOutputsWith, isPendingTx, TransactionVariant } from '@/utils/transactions'
 
-export const useTransactionInfo = (tx: TransactionVariant, addressHash: AddressHash) => {
+export const useTransactionInfo = (tx: TransactionVariant, addressHash: AddressHash, showInternalInflows?: boolean) => {
   const { addresses } = useAddressesContext()
 
   let amount: bigint | undefined = BigInt(0)
@@ -53,7 +53,12 @@ export const useTransactionInfo = (tx: TransactionVariant, addressHash: AddressH
       infoType = 'move'
     } else {
       direction = getDirection(tx, addressHash)
-      infoType = direction === 'out' && hasOnlyOutputsWith(outputs, addresses) ? 'move' : direction
+      const isInternalTransfer = hasOnlyOutputsWith(outputs, addresses)
+      infoType =
+        (isInternalTransfer && showInternalInflows && direction === 'out') ||
+        (isInternalTransfer && !showInternalInflows)
+          ? 'move'
+          : direction
     }
 
     lockTime = outputs.reduce(

--- a/src/hooks/useTransactionInfo.tsx
+++ b/src/hooks/useTransactionInfo.tsx
@@ -25,7 +25,8 @@ import {
 } from '@alephium/sdk'
 import { AssetOutput, Output } from '@alephium/sdk/api/explorer'
 
-import { AddressHash, useAddressesContext } from '@/contexts/addresses'
+import { useAddressesContext } from '@/contexts/addresses'
+import { AddressHash } from '@/types/addresses'
 import { hasOnlyOutputsWith, isPendingTx, TransactionVariant } from '@/utils/transactions'
 
 export const useTransactionInfo = (tx: TransactionVariant, addressHash: AddressHash) => {

--- a/src/pages/NewWallet/CheckWordsPage.tsx
+++ b/src/pages/NewWallet/CheckWordsPage.tsx
@@ -39,9 +39,11 @@ import { useGlobalContext } from '@/contexts/global'
 import { useStepsContext } from '@/contexts/steps'
 import { useWalletContext } from '@/contexts/wallet'
 import { useAppDispatch } from '@/hooks/redux'
+import AddressMetadataStorage from '@/persistent-storage/address-metadata'
 import WalletStorage from '@/persistent-storage/wallet'
 import { walletSaved } from '@/store/activeWalletSlice'
 import { syncAddressesData } from '@/store/addressesSlice'
+import { initialAddressSettings } from '@/utils/addresses'
 
 interface WordKey {
   word: string
@@ -187,6 +189,14 @@ const CheckWordsPage = () => {
   const createEncryptedWallet = () => {
     if (areWordsValid && plainWallet) {
       WalletStorage.store(walletName, password, plainWallet)
+      AddressMetadataStorage.store({
+        index: 0,
+        settings: initialAddressSettings,
+        dataKey: {
+          mnemonic: plainWallet.mnemonic,
+          walletName: walletName
+        }
+      })
       dispatch(
         walletSaved({
           name: walletName,
@@ -195,7 +205,8 @@ const CheckWordsPage = () => {
             index: 0,
             hash: plainWallet.address,
             publicKey: plainWallet.publicKey,
-            privateKey: plainWallet.privateKey
+            privateKey: plainWallet.privateKey,
+            ...initialAddressSettings
           }
         })
       )

--- a/src/pages/NewWallet/CheckWordsPage.tsx
+++ b/src/pages/NewWallet/CheckWordsPage.tsx
@@ -41,6 +41,7 @@ import { useWalletContext } from '@/contexts/wallet'
 import { useAppDispatch } from '@/hooks/redux'
 import WalletStorage from '@/persistent-storage/wallet'
 import { walletSaved } from '@/store/activeWalletSlice'
+import { syncAddressesData } from '@/store/addressesSlice'
 
 interface WordKey {
   word: string
@@ -189,9 +190,16 @@ const CheckWordsPage = () => {
       dispatch(
         walletSaved({
           name: walletName,
-          mnemonic: plainWallet.mnemonic
+          mnemonic: plainWallet.mnemonic,
+          initialAddress: {
+            index: 0,
+            hash: plainWallet.address,
+            publicKey: plainWallet.publicKey,
+            privateKey: plainWallet.privateKey
+          }
         })
       )
+      dispatch(syncAddressesData())
       return true
     }
   }

--- a/src/pages/NewWallet/ImportWordsPage.tsx
+++ b/src/pages/NewWallet/ImportWordsPage.tsx
@@ -39,6 +39,7 @@ import { useAppDispatch } from '@/hooks/redux'
 import useAddressDiscovery from '@/hooks/useAddressDiscovery'
 import WalletStorage from '@/persistent-storage/wallet'
 import { walletSaved } from '@/store/activeWalletSlice'
+import { syncAddressesData } from '@/store/addressesSlice'
 import { bip39Words } from '@/utils/bip39'
 
 const ImportWordsPage = () => {
@@ -84,9 +85,16 @@ const ImportWordsPage = () => {
       dispatch(
         walletSaved({
           name: walletName,
-          mnemonic: wallet.mnemonic
+          mnemonic: wallet.mnemonic,
+          initialAddress: {
+            index: 0,
+            hash: wallet.address,
+            publicKey: wallet.publicKey,
+            privateKey: wallet.privateKey
+          }
         })
       )
+      dispatch(syncAddressesData())
 
       saveNewAddress(
         new Address(wallet.address, wallet.publicKey, wallet.privateKey, 0, { isMain: true }),

--- a/src/pages/NewWallet/ImportWordsPage.tsx
+++ b/src/pages/NewWallet/ImportWordsPage.tsx
@@ -37,9 +37,11 @@ import { useStepsContext } from '@/contexts/steps'
 import { useWalletContext } from '@/contexts/wallet'
 import { useAppDispatch } from '@/hooks/redux'
 import useAddressDiscovery from '@/hooks/useAddressDiscovery'
+import AddressMetadataStorage from '@/persistent-storage/address-metadata'
 import WalletStorage from '@/persistent-storage/wallet'
 import { walletSaved } from '@/store/activeWalletSlice'
 import { syncAddressesData } from '@/store/addressesSlice'
+import { initialAddressSettings } from '@/utils/addresses'
 import { bip39Words } from '@/utils/bip39'
 
 const ImportWordsPage = () => {
@@ -82,6 +84,14 @@ const ImportWordsPage = () => {
       const wallet = walletImport(formatedPhrase)
 
       WalletStorage.store(walletName, password, wallet)
+      AddressMetadataStorage.store({
+        index: 0,
+        settings: initialAddressSettings,
+        dataKey: {
+          mnemonic: wallet.mnemonic,
+          walletName: walletName
+        }
+      })
       dispatch(
         walletSaved({
           name: walletName,
@@ -90,7 +100,8 @@ const ImportWordsPage = () => {
             index: 0,
             hash: wallet.address,
             publicKey: wallet.publicKey,
-            privateKey: wallet.privateKey
+            privateKey: wallet.privateKey,
+            ...initialAddressSettings
           }
         })
       )

--- a/src/pages/UnlockedWallet/AddressDetailsPage.tsx
+++ b/src/pages/UnlockedWallet/AddressDetailsPage.tsx
@@ -40,11 +40,12 @@ import { PageH1, PageH2 } from '@/components/PageComponents/PageHeadings'
 import Table, { TableCell, TableCellPlaceholder, TableRow } from '@/components/Table'
 import Tooltip from '@/components/Tooltip'
 import TransactionalInfo from '@/components/TransactionalInfo'
-import { AddressHash, useAddressesContext } from '@/contexts/addresses'
+import { useAddressesContext } from '@/contexts/addresses'
 import { useAppSelector } from '@/hooks/redux'
 import AddressOptionsModal from '@/modals/AddressOptionsModal'
 import ModalPortal from '@/modals/ModalPortal'
 import TransactionDetailsModal from '@/modals/TransactionDetailsModal'
+import { AddressHash } from '@/types/addresses'
 
 const AddressDetailsPage = () => {
   const { t } = useTranslation()

--- a/src/pages/UnlockedWallet/AddressDetailsPage.tsx
+++ b/src/pages/UnlockedWallet/AddressDetailsPage.tsx
@@ -41,18 +41,22 @@ import Table, { TableCell, TableCellPlaceholder, TableRow } from '@/components/T
 import Tooltip from '@/components/Tooltip'
 import TransactionalInfo from '@/components/TransactionalInfo'
 import { useAddressesContext } from '@/contexts/addresses'
-import { useAppSelector } from '@/hooks/redux'
+import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import AddressOptionsModal from '@/modals/AddressOptionsModal'
 import ModalPortal from '@/modals/ModalPortal'
 import TransactionDetailsModal from '@/modals/TransactionDetailsModal'
+import { syncAddressTransactionsNextPage } from '@/store/addressesSlice'
+import { selectAddressesConfirmedTransactions } from '@/store/confirmedTransactionsSlice'
 import { AddressHash } from '@/types/addresses'
 
 const AddressDetailsPage = () => {
   const { t } = useTranslation()
+  const dispatch = useAppDispatch()
   const navigate = useNavigate()
-  const { getAddress, fetchAddressTransactionsNextPage } = useAddressesContext()
+  const { getAddress } = useAddressesContext()
   const isPassphraseUsed = useAppSelector((state) => state.activeWallet.isPassphraseUsed)
   const { addressHash = '' } = useParams<{ addressHash: AddressHash }>()
+  const confirmedTxs = useAppSelector((state) => selectAddressesConfirmedTransactions(state, [addressHash]))
 
   const [isAddressOptionsModalOpen, setIsAddressOptionsModalOpen] = useState(false)
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction>()
@@ -61,9 +65,7 @@ const AddressDetailsPage = () => {
 
   if (!address) return null
 
-  const loadNextTransactionsPage = () => {
-    fetchAddressTransactionsNextPage(address)
-  }
+  const loadNextTransactionsPage = () => dispatch(syncAddressTransactionsNextPage(address.hash))
 
   const onTransactionClick = (transaction: Transaction) => {
     setSelectedTransaction(transaction)
@@ -152,10 +154,10 @@ const AddressDetailsPage = () => {
           .reverse()
           .map((transaction) => (
             <TableRow role="row" tabIndex={0} key={transaction.txId} blinking>
-              <TransactionalInfo transaction={transaction} isDisplayedInAddressDetailsPage />
+              <TransactionalInfo transaction={transaction} showInternalInflows />
             </TableRow>
           ))}
-        {address.transactions.confirmed.map((transaction) => (
+        {confirmedTxs.map((transaction) => (
           <TableRow
             role="row"
             tabIndex={0}
@@ -163,17 +165,17 @@ const AddressDetailsPage = () => {
             onClick={() => onTransactionClick(transaction)}
             onKeyPress={() => onTransactionClick(transaction)}
           >
-            <TransactionalInfo transaction={transaction} isDisplayedInAddressDetailsPage />
+            <TransactionalInfo transaction={transaction} showInternalInflows />
           </TableRow>
         ))}
-        {address.transactions.confirmed.length !== address.details.txNumber && (
+        {confirmedTxs.length !== address.details.txNumber && (
           <TableRow role="row">
             <TableCell align="center" role="gridcell">
               <ActionLink onClick={loadNextTransactionsPage}>{t`Show more`}</ActionLink>
             </TableCell>
           </TableRow>
         )}
-        {address.transactions.pending.length === 0 && address.transactions.confirmed.length === 0 && (
+        {address.transactions.pending.length === 0 && confirmedTxs.length === 0 && (
           <TableRow role="row" tabIndex={0}>
             <TableCellPlaceholder align="center" role="gridcell">
               {t`No transactions to display`}

--- a/src/pages/UnlockedWallet/AddressesPage/AddressCard.tsx
+++ b/src/pages/UnlockedWallet/AddressesPage/AddressCard.tsx
@@ -29,9 +29,10 @@ import AddressEllipsed from '@/components/AddressEllipsed'
 import Amount from '@/components/Amount'
 import Badge from '@/components/Badge'
 import Card from '@/components/Card'
-import { AddressHash, useAddressesContext } from '@/contexts/addresses'
+import { useAddressesContext } from '@/contexts/addresses'
 import { ReactComponent as RibbonSVG } from '@/images/ribbon.svg'
 import { useGetPriceQuery } from '@/store/priceApiSlice'
+import { AddressHash } from '@/types/addresses'
 import { currencies } from '@/utils/currencies'
 
 interface AddressCardProps {

--- a/src/pages/UnlockedWallet/AddressesPage/AddressesTabContent.tsx
+++ b/src/pages/UnlockedWallet/AddressesPage/AddressesTabContent.tsx
@@ -24,7 +24,6 @@ import Toggle from '@/components/Inputs/Toggle'
 import { useAddressesContext } from '@/contexts/addresses'
 import ModalPortal from '@/modals/ModalPortal'
 import NewAddressModal from '@/modals/NewAddressModal'
-import { sortAddressList } from '@/utils/addresses'
 
 import AddressCard from './AddressCard'
 import TabContent from './TabContent'
@@ -78,7 +77,8 @@ const AddressesTabContent = () => {
         </HideEmptyAddressesToggle>
       }
     >
-      {sortAddressList(visibleAddresses).map((address) => (
+      {/* TODO: Use sortAddressList(visibleAddresses) when dependency from contexts/addresses is removed */}
+      {visibleAddresses.map((address) => (
         <AddressCard hash={address.hash} key={address.hash} />
       ))}
 

--- a/src/pages/UnlockedWallet/OverviewPage/TransactionList.tsx
+++ b/src/pages/UnlockedWallet/OverviewPage/TransactionList.tsx
@@ -29,11 +29,11 @@ import { useAppSelector } from '@/hooks/redux'
 import { selectAddressIds } from '@/store/addressesSlice'
 import { selectAddressesConfirmedTransactions } from '@/store/confirmedTransactionsSlice'
 import { AddressHash } from '@/types/addresses'
-import { AddressTransaction, PendingTx } from '@/types/transactions'
+import { AddressConfirmedTransaction, PendingTx } from '@/types/transactions'
 import { BelongingToAddress, getTransactionsForAddresses } from '@/utils/transactions'
 
 interface OverviewPageTransactionListProps {
-  onTransactionClick: (transaction: AddressTransaction) => void
+  onTransactionClick: (transaction: AddressConfirmedTransaction) => void
   limit?: number
   className?: string
 }

--- a/src/pages/UnlockedWallet/OverviewPage/index.tsx
+++ b/src/pages/UnlockedWallet/OverviewPage/index.tsx
@@ -16,14 +16,15 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Transaction } from '@alephium/sdk/api/explorer'
+// import { Transaction } from '@alephium/sdk/api/explorer'
 import { motion } from 'framer-motion'
 import { useState } from 'react'
 
 import { fadeIn } from '@/animations'
-import { Address, useAddressesContext } from '@/contexts/addresses'
+import { useAddressesContext } from '@/contexts/addresses'
 import ModalPortal from '@/modals/ModalPortal'
-import TransactionDetailsModal from '@/modals/TransactionDetailsModal'
+// import TransactionDetailsModal from '@/modals/TransactionDetailsModal'
+import { AddressConfirmedTransaction } from '@/types/transactions'
 
 import { UnlockedWalletPanel } from '../UnlockedWalletLayout'
 import AmountsOverviewPanel from './AmountsOverviewPanel'
@@ -32,7 +33,7 @@ import TransactionList from './TransactionList'
 const OverviewPage = () => {
   const { isLoadingData } = useAddressesContext()
 
-  const [selectedTransaction, setSelectedTransaction] = useState<Transaction & { address: Address }>()
+  const [selectedTransaction, setSelectedTransaction] = useState<AddressConfirmedTransaction>()
 
   return (
     <motion.div {...fadeIn}>
@@ -40,14 +41,16 @@ const OverviewPage = () => {
         <AmountsOverviewPanel isLoading={isLoadingData} />
         <TransactionList onTransactionClick={setSelectedTransaction} limit={5} />
 
+        {/* TODO: Uncomment when dependency from contexts/addresses is removed */}
         <ModalPortal>
-          {selectedTransaction && (
+          {selectedTransaction?.hash}
+          {/* {selectedTransaction && (
             <TransactionDetailsModal
               address={selectedTransaction.address}
               transaction={selectedTransaction}
               onClose={() => setSelectedTransaction(undefined)}
             />
-          )}
+          )} */}
         </ModalPortal>
       </UnlockedWalletPanel>
     </motion.div>

--- a/src/pages/UnlockedWallet/TransfersPage/TransactionList.tsx
+++ b/src/pages/UnlockedWallet/TransfersPage/TransactionList.tsx
@@ -16,41 +16,41 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { getDirection } from '@alephium/sdk'
-import { Transaction } from '@alephium/sdk/api/explorer'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import ActionLink from '@/components/ActionLink'
 import Table, { TableCell, TableCellPlaceholder, TableRow } from '@/components/Table'
 import TransactionalInfo from '@/components/TransactionalInfo'
-import { Address, useAddressesContext } from '@/contexts/addresses'
-import { PendingTx } from '@/types/transactions'
-import { GENESIS_TIMESTAMP } from '@/utils/constants'
-import { BelongingToAddress, getTransactionsForAddresses, hasOnlyInputsWith } from '@/utils/transactions'
+import { useAddressesContext } from '@/contexts/addresses'
+import { useAppDispatch, useAppSelector } from '@/hooks/redux'
+import { selectAddressIds, selectAllAddresses, syncAllAddressesTransactionsNextPage } from '@/store/addressesSlice'
+import { selectAddressesConfirmedTransactions } from '@/store/confirmedTransactionsSlice'
+import { AddressHash } from '@/types/addresses'
+import { AddressTransaction, PendingTx } from '@/types/transactions'
+import { BelongingToAddress, getTransactionsForAddresses } from '@/utils/transactions'
 
 interface TransfersPageTransactionListProps {
-  onTransactionClick: (transaction: Transaction & { address: Address }) => void
+  onTransactionClick: (transaction: AddressTransaction) => void
   className?: string
 }
 
 const TransfersPageTransactionList = ({ className, onTransactionClick }: TransfersPageTransactionListProps) => {
   const { t } = useTranslation()
-  const { addresses, isLoadingData, fetchAddressTransactionsNextPage } = useAddressesContext()
+  const dispatch = useAppDispatch()
+  const { addresses: contextAddresses, isLoadingData } = useAddressesContext()
+  const addresses = useAppSelector(selectAllAddresses)
+  const addressHashes = useAppSelector(selectAddressIds) as AddressHash[]
+  const [allConfirmedTxs, allTransactionsLoaded] = useAppSelector((s) => [
+    selectAddressesConfirmedTransactions(s, addressHashes),
+    s.addresses.allTransactionsLoaded
+  ])
 
-  const allConfirmedTxs = getTransactionsForAddresses('confirmed', addresses)
-  const allPendingTxs = getTransactionsForAddresses('pending', addresses)
-  const totalNumberOfTransactions = addresses.map((address) => address.details.txNumber).reduce((a, b) => a + b, 0)
+  const allPendingTxs = getTransactionsForAddresses('pending', contextAddresses)
+  const totalNumberOfTransactions = addresses.map((address) => address.txNumber).reduce((a, b) => a + b, 0)
   const showSkeletonLoading = isLoadingData && !allConfirmedTxs.length && !allPendingTxs.length
 
-  const loadNextTransactionsPage = async () => addresses.forEach((address) => fetchAddressTransactionsNextPage(address))
-
-  const shouldHideTx = (tx: Transaction, address: Address) =>
-    tx.inputs &&
-    tx.inputs.length > 0 &&
-    hasOnlyInputsWith(tx.inputs, addresses) &&
-    getDirection(tx, address.hash) == 'in' &&
-    tx.timestamp !== GENESIS_TIMESTAMP
+  const loadNextTransactionsPage = () => dispatch(syncAllAddressesTransactionsNextPage())
 
   return (
     <Table isLoading={showSkeletonLoading} className={className} minWidth="500px">
@@ -62,24 +62,34 @@ const TransfersPageTransactionList = ({ className, onTransactionClick }: Transfe
           <TransactionalInfo transaction={tx} addressHash={address.hash} />
         </TableRow>
       ))}
-      {allConfirmedTxs.map(({ data: tx, address }: BelongingToAddress<Transaction>) => {
-        if (shouldHideTx(tx, address)) return null
-        return (
-          <TableRow
-            key={`${tx.hash}-${address.hash}`}
-            role="row"
-            tabIndex={0}
-            onClick={() => onTransactionClick({ ...tx, address })}
-            onKeyPress={() => onTransactionClick({ ...tx, address })}
-          >
-            <TransactionalInfo transaction={tx} addressHash={address.hash} />
-          </TableRow>
-        )
-      })}
+      {allConfirmedTxs.map((confirmedTx) => (
+        <TableRow
+          key={`${confirmedTx.hash}-${confirmedTx.address.hash}`}
+          role="row"
+          tabIndex={0}
+          onClick={() => onTransactionClick(confirmedTx)}
+          onKeyPress={() => onTransactionClick(confirmedTx)}
+        >
+          <TransactionalInfo transaction={confirmedTx} addressHash={confirmedTx.address.hash} />
+        </TableRow>
+      ))}
       {allConfirmedTxs.length !== totalNumberOfTransactions && (
         <TableRow role="row">
           <TableCell align="center" role="gridcell">
-            <ActionLink onClick={loadNextTransactionsPage}>{t`Show more`}</ActionLink>
+            {allTransactionsLoaded ? (
+              // TODO: Do we want to show a message here?
+              <div>All transactions loaded!</div>
+            ) : (
+              // TODO: Since we "squash" transactions between internal addresses and mark them as "moved", we have the
+              // problem where fetching the next page returns transactions we already have, so the UI doesn't show any
+              // update. In the testnet genesis wallet, for example, once you generate 4 addresses, you need to click 3
+              // times "Show more" to get new transactions. This is because we fetch the 1st tx page of each individiual
+              // address (using `GET:/addresses/{address}/transactions`) once the wallet gets unlocked. Then, when we
+              // click "Show more" (querying `POST:/addresses/transactions`) it happens that we receive txs that we
+              // already have. This could be improved by making further requests until we get some data, or until we get
+              // to the end of the transaction history.
+              <ActionLink onClick={loadNextTransactionsPage}>{t`Show more`}</ActionLink>
+            )}
           </TableCell>
         </TableRow>
       )}

--- a/src/pages/UnlockedWallet/TransfersPage/TransactionList.tsx
+++ b/src/pages/UnlockedWallet/TransfersPage/TransactionList.tsx
@@ -27,11 +27,11 @@ import { useAppDispatch, useAppSelector } from '@/hooks/redux'
 import { selectAddressIds, selectAllAddresses, syncAllAddressesTransactionsNextPage } from '@/store/addressesSlice'
 import { selectAddressesConfirmedTransactions } from '@/store/confirmedTransactionsSlice'
 import { AddressHash } from '@/types/addresses'
-import { AddressTransaction, PendingTx } from '@/types/transactions'
+import { AddressConfirmedTransaction, PendingTx } from '@/types/transactions'
 import { BelongingToAddress, getTransactionsForAddresses } from '@/utils/transactions'
 
 interface TransfersPageTransactionListProps {
-  onTransactionClick: (transaction: AddressTransaction) => void
+  onTransactionClick: (transaction: AddressConfirmedTransaction) => void
   className?: string
 }
 

--- a/src/pages/UnlockedWallet/TransfersPage/index.tsx
+++ b/src/pages/UnlockedWallet/TransfersPage/index.tsx
@@ -16,33 +16,35 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Transaction } from '@alephium/sdk/api/explorer'
+// import { Transaction } from '@alephium/sdk/api/explorer'
 import { motion } from 'framer-motion'
 import { useState } from 'react'
 
 import { fadeIn } from '@/animations'
-import { Address } from '@/contexts/addresses'
 import ModalPortal from '@/modals/ModalPortal'
-import TransactionDetailsModal from '@/modals/TransactionDetailsModal'
+// import TransactionDetailsModal from '@/modals/TransactionDetailsModal'
+import { AddressConfirmedTransaction } from '@/types/transactions'
 
 import { UnlockedWalletPanel } from '../UnlockedWalletLayout'
 import TransactionList from './TransactionList'
 
 const TransfersPage = () => {
-  const [selectedTransaction, setSelectedTransaction] = useState<Transaction & { address: Address }>()
+  const [selectedTransaction, setSelectedTransaction] = useState<AddressConfirmedTransaction>()
 
   return (
     <motion.div {...fadeIn}>
       <UnlockedWalletPanel top>
         <TransactionList onTransactionClick={setSelectedTransaction} />
         <ModalPortal>
-          {selectedTransaction && (
+          {selectedTransaction?.hash}
+          {/* TODO: Uncomment when dependency from contexts/addresses is removed */}
+          {/* {selectedTransaction && (
             <TransactionDetailsModal
               address={selectedTransaction.address}
               transaction={selectedTransaction}
               onClose={() => setSelectedTransaction(undefined)}
             />
-          )}
+          )} */}
         </ModalPortal>
       </UnlockedWalletPanel>
     </motion.div>

--- a/src/persistent-storage/address-metadata.ts
+++ b/src/persistent-storage/address-metadata.ts
@@ -16,16 +16,23 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AddressMetadata, AddressSettings } from '@/types/addresses'
+import { AddressMetadata, AddressSettingsRedux } from '@/types/addresses'
 import { latestAddressMetadataVersion } from '@/utils/migration'
 
 import { DataKey, PersistentEncryptedStorage } from './encrypted-storage'
 
+interface AddressMetadataStorageStoreProps {
+  dataKey: DataKey
+  index: number
+  settings: AddressSettingsRedux
+  isPassphraseUsed?: boolean
+}
+
 class AddressMetadataStorage extends PersistentEncryptedStorage {
-  store({ mnemonic, walletName }: DataKey, index: number, settings: AddressSettings, isPassphraseUsed?: boolean) {
+  store({ dataKey, index, settings, isPassphraseUsed }: AddressMetadataStorageStoreProps) {
     if (isPassphraseUsed) return
 
-    const addressesMetadata = this.load({ walletName, mnemonic })
+    const addressesMetadata = this.load(dataKey)
     const existingAddressMetadata = addressesMetadata.find((data: AddressMetadata) => data.index === index)
 
     if (!existingAddressMetadata) {
@@ -38,7 +45,7 @@ class AddressMetadataStorage extends PersistentEncryptedStorage {
     }
     console.log(`🟠 Storing address index ${index} metadata locally`)
 
-    super._store(JSON.stringify(addressesMetadata), { mnemonic, walletName }, isPassphraseUsed)
+    super._store(JSON.stringify(addressesMetadata), dataKey, isPassphraseUsed)
   }
 }
 

--- a/src/store/activeWalletSlice.ts
+++ b/src/store/activeWalletSlice.ts
@@ -18,13 +18,11 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
+import { ActiveWallet, GeneratedWallet } from '@/types/wallet'
+
 const sliceName = 'activeWallet'
 
-interface ActiveWalletState {
-  name?: string
-  mnemonic?: string
-  isPassphraseUsed?: boolean
-}
+type ActiveWalletState = Partial<ActiveWallet>
 
 const initialState: ActiveWalletState = {
   name: undefined,
@@ -36,7 +34,7 @@ const activeWalletSlice = createSlice({
   name: sliceName,
   initialState,
   reducers: {
-    walletSaved: (_, action: PayloadAction<Required<Pick<ActiveWalletState, 'name' | 'mnemonic'>>>) => action.payload,
+    walletSaved: (_, action: PayloadAction<GeneratedWallet>) => action.payload,
     walletUnlocked: (_, action: PayloadAction<ActiveWalletState>) => action.payload,
     walletLocked: () => initialState,
     walletDeleted: (state, action: PayloadAction<string>) => {

--- a/src/store/addressesSlice.ts
+++ b/src/store/addressesSlice.ts
@@ -1,0 +1,140 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { addressToGroup, TOTAL_NUMBER_OF_GROUPS } from '@alephium/sdk'
+import { createAsyncThunk, createEntityAdapter, createSelector, createSlice, EntityState } from '@reduxjs/toolkit'
+import { uniq } from 'lodash'
+
+import { fetchAddressesData } from '@/api/addresses'
+import { AddressHash, AddressRedux } from '@/types/addresses'
+import { getRandomLabelColor } from '@/utils/colors'
+
+import { walletSaved } from './activeWalletSlice'
+import { RootState } from './store'
+
+const sliceName = 'addresses'
+
+const addressesAdapter = createEntityAdapter<AddressRedux>({
+  selectId: (address) => address.hash,
+  sortComparer: (a, b) => {
+    // Always keep main address to the top of the list
+    if (a.isDefault) return -1
+    if (b.isDefault) return 1
+    return (b.lastUsed ?? 0) - (a.lastUsed ?? 0)
+  }
+})
+
+interface AddressesState extends EntityState<AddressRedux> {
+  loading: boolean
+  status: 'uninitialized' | 'initialized'
+}
+
+const initialState: AddressesState = addressesAdapter.getInitialState({
+  loading: false,
+  status: 'uninitialized'
+})
+
+export const syncAddressesData = createAsyncThunk(
+  `${sliceName}/syncAddressesData`,
+  async (payload: AddressHash[] | undefined, { getState, dispatch }) => {
+    dispatch(loadingStarted())
+
+    const state = getState() as RootState
+    const addresses = payload ?? (state.addresses.ids as AddressHash[])
+    const results = await fetchAddressesData(addresses)
+
+    return results
+  }
+)
+
+const addressesSlice = createSlice({
+  name: sliceName,
+  initialState,
+  reducers: {
+    loadingStarted: (state) => {
+      state.loading = true
+    }
+  },
+  extraReducers(builder) {
+    builder
+      .addCase(walletSaved, (state, action) => {
+        const { initialAddress } = action.payload
+
+        addressesAdapter.setAll(state, [])
+        addressesAdapter.addOne(state, {
+          ...initialAddress,
+          group: addressToGroup(initialAddress.hash, TOTAL_NUMBER_OF_GROUPS),
+          color: getRandomLabelColor(),
+          isDefault: true,
+          balance: '0',
+          lockedBalance: '0',
+          txNumber: 0,
+          transactions: [],
+          transactionsPageLoaded: 0,
+          allTransactionPagesLoaded: false,
+          tokens: [],
+          lastUsed: 0
+        })
+        state.status = 'uninitialized'
+      })
+      .addCase(syncAddressesData.fulfilled, (state, action) => {
+        const addressData = action.payload
+        const updatedAddresses = addressData.map(({ hash, details, tokens, transactions }) => {
+          const address = state.entities[hash] as AddressRedux
+
+          return {
+            id: hash,
+            changes: {
+              ...details,
+              tokens,
+              transactions: uniq(address.transactions.concat(transactions.map((tx) => tx.hash))),
+              transactionsPageLoaded: address.transactionsPageLoaded === 0 ? 1 : address.transactionsPageLoaded,
+              lastUsed: transactions.length > 0 ? transactions[0].timestamp : address.lastUsed
+            }
+          }
+        })
+
+        addressesAdapter.updateMany(state, updatedAddresses)
+
+        state.status = 'initialized'
+        state.loading = false
+      })
+  }
+})
+
+export const { loadingStarted } = addressesSlice.actions
+
+export const {
+  selectById: selectAddressByHash,
+  selectAll: selectAllAddresses,
+  selectIds: selectAddressIds
+} = addressesAdapter.getSelectors<RootState>((state) => state[sliceName])
+
+export const selectHaveAllPagesLoaded = createSelector(selectAllAddresses, (addresses) =>
+  addresses.every((address) => address.allTransactionPagesLoaded)
+)
+
+export const selectDefaultAddress = createSelector(selectAllAddresses, (addresses) =>
+  addresses.find((address) => address.isDefault)
+)
+
+export const selectTotalBalance = createSelector([selectAllAddresses], (addresses) =>
+  addresses.reduce((acc, address) => acc + BigInt(address.balance), BigInt(0))
+)
+
+export default addressesSlice

--- a/src/store/confirmedTransactionsSlice.ts
+++ b/src/store/confirmedTransactionsSlice.ts
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Transaction } from '@alephium/sdk/api/explorer'
+import { createEntityAdapter, createSelector, createSlice, EntityState, PayloadAction } from '@reduxjs/toolkit'
+
+import { AddressHash } from '../types/addresses'
+import { AddressConfirmedTransaction } from '../types/transactions'
+import { selectAddressTransactions } from '../utils/addresses'
+import {
+  selectAllAddresses,
+  syncAddressesData,
+  syncAddressTransactionsNextPage,
+  syncAllAddressesTransactionsNextPage
+} from './addressesSlice'
+import { RootState } from './store'
+
+const sliceName = 'confirmedTransactions'
+
+type ConfirmedTransactionsState = EntityState<Transaction>
+
+const confirmedTransactionsAdapter = createEntityAdapter<Transaction>({
+  selectId: (transaction) => transaction.hash,
+  sortComparer: (a, b) => b.timestamp - a.timestamp
+})
+
+const initialState: ConfirmedTransactionsState = confirmedTransactionsAdapter.getInitialState()
+
+const confirmedTransactionsSlice = createSlice({
+  name: sliceName,
+  initialState,
+  reducers: {},
+  extraReducers(builder) {
+    builder
+      .addCase(syncAddressesData.fulfilled, addTransactions)
+      .addCase(syncAddressTransactionsNextPage.fulfilled, addTransactions)
+      .addCase(syncAllAddressesTransactionsNextPage.fulfilled, addTransactions)
+  }
+})
+
+export const { selectAll: selectAllConfirmedTransactions } = confirmedTransactionsAdapter.getSelectors<RootState>(
+  (state) => state[sliceName]
+)
+
+export const selectAddressesConfirmedTransactions = createSelector(
+  [selectAllAddresses, selectAllConfirmedTransactions, (_, addressHashes: AddressHash[]) => addressHashes],
+  (allAddresses, confirmedTransactions, addressHashes): AddressConfirmedTransaction[] =>
+    selectAddressTransactions(allAddresses, confirmedTransactions, addressHashes) as AddressConfirmedTransaction[]
+)
+
+export default confirmedTransactionsSlice
+
+const addTransactions = (
+  state: ConfirmedTransactionsState,
+  action: PayloadAction<{ transactions: Transaction[] }[] | { transactions: Transaction[] } | undefined>
+) => {
+  const transactions = Array.isArray(action.payload)
+    ? action.payload.flatMap((address) => address.transactions)
+    : action.payload?.transactions
+
+  if (transactions && transactions.length > 0) {
+    confirmedTransactionsAdapter.upsertMany(state, transactions)
+  }
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -19,6 +19,8 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { configureStore } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/dist/query'
 
+import confirmedTransactionsSlice from '@/store/confirmedTransactionsSlice'
+
 import activeWalletSlice from './activeWalletSlice'
 import addressesSlice from './addressesSlice'
 import appSlice from './appSlice'
@@ -35,6 +37,7 @@ export const store = configureStore({
     [settingsSlice.name]: settingsSlice.reducer,
     [networkSlice.name]: networkSlice.reducer,
     [addressesSlice.name]: addressesSlice.reducer,
+    [confirmedTransactionsSlice.name]: confirmedTransactionsSlice.reducer,
     [priceApi.reducerPath]: priceApi.reducer
   },
   middleware: (getDefaultMiddleware) =>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -20,6 +20,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/dist/query'
 
 import activeWalletSlice from './activeWalletSlice'
+import addressesSlice from './addressesSlice'
 import appSlice from './appSlice'
 import contactsSlice from './contactsSlice'
 import networkSlice, { networkListenerMiddleware } from './networkSlice'
@@ -33,6 +34,7 @@ export const store = configureStore({
     [contactsSlice.name]: contactsSlice.reducer,
     [settingsSlice.name]: settingsSlice.reducer,
     [networkSlice.name]: networkSlice.reducer,
+    [addressesSlice.name]: addressesSlice.reducer,
     [priceApi.reducerPath]: priceApi.reducer
   },
   middleware: (getDefaultMiddleware) =>

--- a/src/types/addresses.ts
+++ b/src/types/addresses.ts
@@ -16,6 +16,12 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { AddressKeyPair } from '@alephium/sdk'
+import { AddressBalance, AddressInfo, Token, Transaction } from '@alephium/sdk/api/explorer'
+
+import { TimeInMs } from './numbers'
+import { PendingTransaction } from './transactions'
+
 export type AddressSettings = {
   isMain: boolean
   label?: string
@@ -25,3 +31,25 @@ export type AddressSettings = {
 export type AddressMetadata = AddressSettings & {
   index: number
 }
+
+export type AddressSettingsRedux = {
+  isDefault: boolean
+  color: string
+  label?: string
+}
+
+export type AddressRedux = AddressKeyPair &
+  AddressInfo &
+  AddressSettingsRedux & {
+    group: number
+    transactions: (Transaction['hash'] | PendingTransaction['hash'])[]
+    transactionsPageLoaded: number
+    allTransactionPagesLoaded: boolean
+    tokens: {
+      id: Token['id']
+      balances: AddressBalance
+    }[]
+    lastUsed: TimeInMs
+  }
+
+export type AddressHash = string

--- a/src/types/addresses.ts
+++ b/src/types/addresses.ts
@@ -38,9 +38,10 @@ export type AddressSettingsRedux = {
   label?: string
 }
 
-export type AddressRedux = AddressKeyPair &
-  AddressInfo &
-  AddressSettingsRedux & {
+export type AddressBase = AddressKeyPair & AddressSettingsRedux
+
+export type AddressRedux = AddressBase &
+  AddressInfo & {
     group: number
     transactions: (Transaction['hash'] | PendingTransaction['hash'])[]
     transactionsPageLoaded: number

--- a/src/types/contacts.ts
+++ b/src/types/contacts.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AddressHash } from './addresses'
+import { AddressHash } from '@/types/addresses'
 
 export type Contact = {
   id?: string

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -44,6 +44,17 @@ export type PendingTx = {
   status: 'pending'
 }
 
+export type PendingTransaction = {
+  hash: string
+  fromAddress: string
+  toAddress: string
+  timestamp: number
+  type: PendingTxType
+  amount?: string
+  lockTime?: number
+  status: 'pending'
+}
+
 export type DappTxData = TransferTxData | DeployContractTxData | ScriptTxData
 
 export type TxDataToModalType =

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -17,8 +17,10 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { SweepAddressTransaction } from '@alephium/sdk/api/alephium'
+import { Transaction } from '@alephium/sdk/api/explorer'
 
 import { Address } from '@/contexts/addresses'
+import { AddressRedux } from '@/types/addresses'
 import { NetworkName } from '@/types/network'
 
 export type TransactionDirection = 'out' | 'in'
@@ -137,3 +139,7 @@ export type TxContext = {
   currentNetwork: NetworkName
   setAddress: (address: Address) => void
 }
+
+export type AddressConfirmedTransaction = Transaction & { address: AddressRedux }
+export type AddressPendingTransaction = PendingTransaction & { address: AddressRedux }
+export type AddressTransaction = AddressConfirmedTransaction | AddressPendingTransaction

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AddressKeyPair } from '@alephium/sdk'
+import { AddressBase } from '@/types/addresses'
 
 export type ActiveWallet = {
   name: string
@@ -25,5 +25,5 @@ export type ActiveWallet = {
 }
 
 export type GeneratedWallet = ActiveWallet & {
-  initialAddress: AddressKeyPair
+  initialAddress: AddressBase
 }

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -16,10 +16,14 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AddressHash } from './addresses'
+import { AddressKeyPair } from '@alephium/sdk'
 
-export type Contact = {
-  id?: string
+export type ActiveWallet = {
   name: string
-  address: AddressHash
+  mnemonic: string
+  isPassphraseUsed?: boolean
+}
+
+export type GeneratedWallet = ActiveWallet & {
+  initialAddress: AddressKeyPair
 }

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -16,12 +16,31 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Address } from '@/contexts/addresses'
+import { Transaction } from '@alephium/sdk/api/explorer'
 
-export const sortAddressList = (addresses: Address[]): Address[] =>
+import { AddressHash, AddressRedux } from '@/types/addresses'
+import { AddressTransaction, PendingTransaction } from '@/types/transactions'
+
+export const sortAddressList = (addresses: AddressRedux[]): AddressRedux[] =>
   addresses.sort((a, b) => {
     // Always keep default address to the top of the list
-    if (a.settings.isMain) return -1
-    if (b.settings.isMain) return 1
+    if (a.isDefault) return -1
+    if (b.isDefault) return 1
     return (b.lastUsed ?? 0) - (a.lastUsed ?? 0)
   })
+
+export const selectAddressTransactions = (
+  allAddresses: AddressRedux[],
+  transactions: (Transaction | PendingTransaction)[],
+  addressHashes: AddressHash[]
+) => {
+  const addresses = allAddresses.filter((address) => addressHashes.includes(address.hash))
+  const addressesTxs = addresses.flatMap((address) => address.transactions.map((txHash) => ({ txHash, address })))
+
+  return transactions.reduce((txs, tx) => {
+    const addressTx = addressesTxs.find(({ txHash }) => txHash === tx.hash)
+    if (addressTx) txs.push({ ...tx, address: addressTx.address })
+
+    return txs
+  }, [] as AddressTransaction[])
+}

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -20,6 +20,7 @@ import { Transaction } from '@alephium/sdk/api/explorer'
 
 import { AddressHash, AddressRedux } from '@/types/addresses'
 import { AddressTransaction, PendingTransaction } from '@/types/transactions'
+import { getRandomLabelColor } from '@/utils/colors'
 
 export const sortAddressList = (addresses: AddressRedux[]): AddressRedux[] =>
   addresses.sort((a, b) => {
@@ -43,4 +44,9 @@ export const selectAddressTransactions = (
 
     return txs
   }, [] as AddressTransaction[])
+}
+
+export const initialAddressSettings = {
+  isDefault: true,
+  color: getRandomLabelColor()
 }

--- a/src/utils/api-clients.ts
+++ b/src/utils/api-clients.ts
@@ -19,7 +19,8 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { CliqueClient, ExplorerClient } from '@alephium/sdk'
 import { NodeProvider as Web3Client } from '@alephium/web3'
 
-import { Address, AddressHash } from '@/contexts/addresses'
+import { Address } from '@/contexts/addresses'
+import { AddressHash } from '@/types/addresses'
 import { NetworkName } from '@/types/network'
 import { Settings } from '@/types/settings'
 import { PendingTxType } from '@/types/transactions'

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -24,7 +24,8 @@ import {
 } from '@alephium/sdk'
 import { Input, Output, Transaction, UnconfirmedTransaction } from '@alephium/sdk/api/explorer'
 
-import { Address, AddressHash } from '@/contexts/addresses'
+import { Address } from '@/contexts/addresses'
+import { AddressHash } from '@/types/addresses'
 import { NetworkName } from '@/types/network'
 import { PendingTx, TransactionStatus } from '@/types/transactions'
 

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -22,7 +22,7 @@ import {
   MIN_UTXO_SET_AMOUNT,
   removeConsolidationChangeAmount
 } from '@alephium/sdk'
-import { Input, Output, Transaction, UnconfirmedTransaction } from '@alephium/sdk/api/explorer'
+import { Output, Transaction, UnconfirmedTransaction } from '@alephium/sdk/api/explorer'
 
 import { Address } from '@/contexts/addresses'
 import { AddressHash } from '@/types/addresses'
@@ -68,9 +68,6 @@ export function sortTransactions(a: HasTimestamp, b: HasTimestamp): number {
 
   return delta
 }
-
-export const hasOnlyInputsWith = (inputs: Input[], addresses: Address[]): boolean =>
-  inputs.every((i) => i?.address && addresses.map((a) => a.hash).indexOf(i.address) >= 0)
 
 export const hasOnlyOutputsWith = (outputs: Output[], addresses: Address[]): boolean =>
   outputs.every((o) => o?.address && addresses.map((a) => a.hash).indexOf(o.address) >= 0)

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -127,3 +127,11 @@ export const expectedAmount = (data: { fromAddress: Address; alphAmount?: string
 
   return expectedAmount
 }
+
+export const extractNewTransactionHashes = (
+  incomingTransactions: Transaction[],
+  existingTransactions: Transaction['hash'][]
+): Transaction['hash'][] =>
+  incomingTransactions
+    .filter((newTx) => !existingTransactions.some((existingTx) => existingTx === newTx.hash))
+    .map((tx) => tx.hash)


### PR DESCRIPTION
To start working on integrating tokens, I want to make sure I can store them in Redux and not in our legacy contexts. To do that, I had to start moving away from the `addresses` context and into the `addressesSlice`. This PR is some necessary changes I needed to make so that I can later on start working on tokens. I had to stop making changes to keep the PR in reasonable size. I've added multiple TODOs. I will then work on pending transactions and if there's enough space, tokens.

- Duplicated client outside of the global context (will need to remove the one in the global context once all dependencies from it are removed)
- Started the `addressesSlice` and `confirmedTransactionsSlice` and added data to them when:
   - creating a new wallet
   - restoring a wallet
   - unlocking a wallet
   - fetching next transactions page of all addresses from Transfers page
   - fetching next transactions page of a specific address from the Address Detail page