### PR TITLE
Fix switching to system theme settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,10 +54,10 @@ const App = () => {
   const pendingTxHashes = useAppSelector((s) => selectAddressesPendingTransactions(s, addressHashes)).map(
     (tx) => tx.address.hash
   )
-  const [settings, network, addressesStatus, isPassphraseUsed, assetsInfo, loading] = useAppSelector((s) => [
-    s.settings,
+  const [network, addressesStatus, theme, isPassphraseUsed, assetsInfo, loading] = useAppSelector((s) => [
     s.network,
     s.addresses.status,
+    s.app.theme,
     s.activeWallet.isPassphraseUsed,
     s.assetsInfo,
     s.app.loading
@@ -142,7 +142,7 @@ const App = () => {
   }, [newVersionDownloadTriggered])
 
   return (
-    <ThemeProvider theme={settings.theme === 'light' ? lightTheme : darkTheme}>
+    <ThemeProvider theme={theme === 'light' ? lightTheme : darkTheme}>
       <GlobalStyle />
 
       {splashScreenVisible && <SplashScreen onSplashScreenShown={() => setSplashScreenVisible(false)} />}

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -21,22 +21,17 @@ import { useTranslation } from 'react-i18next'
 
 import Toggle from '@/components/Inputs/Toggle'
 import { useAppSelector } from '@/hooks/redux'
-import useSwitchTheme from '@/hooks/useSwitchTheme'
+import { switchTheme } from '@/storage/storage-utils/settingsStorageUtils'
 
-interface ThemeSwitcherProps {
-  className?: string
-}
-
-const ThemeSwitcher: FC<ThemeSwitcherProps> = ({ className }) => {
+const ThemeSwitcher = () => {
   const { t } = useTranslation()
-  const switchTheme = useSwitchTheme()
-  const { theme: currentTheme } = useAppSelector((state) => state.settings)
+  const { theme } = useAppSelector((state) => state.app)
 
-  const isDark = currentTheme === 'dark'
+  const isDark = theme === 'dark'
 
   return (
     <Toggle
-      label={t`Activate dark mode`}
+      label={t('Activate dark mode')}
       ToggleIcons={[Sun, Moon]}
       handleColors={['var(--color-orange)', 'var(--color-purple)']}
       toggled={isDark}

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -28,7 +28,7 @@ import useAddressGeneration from '@/hooks/useAddressGeneration'
 import useIdleForTooLong from '@/hooks/useIdleForTooLong'
 import useLatestGitHubRelease from '@/hooks/useLatestGitHubRelease'
 import { walletLocked, walletSwitched, walletUnlocked } from '@/storage/app-state/slices/activeWalletSlice'
-import { themeChanged } from '@/storage/app-state/slices/settingsSlice'
+import { osThemeChangeDetected } from '@/storage/app-state/slices/appSlice'
 import WalletStorage from '@/storage/persistent-storage/walletPersistentStorage'
 import { AlephiumWindow } from '@/types/window'
 import { migrateUserData } from '@/utils/migration'
@@ -125,11 +125,11 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
     if (!shouldListenToOSThemeChanges) return
 
     const removeOSThemeChangeListener = electron?.theme.onShouldUseDarkColors((useDark: boolean) =>
-      dispatch(themeChanged(useDark ? 'dark' : 'light'))
+      dispatch(osThemeChangeDetected(useDark ? 'dark' : 'light'))
     )
 
     const removeGetNativeThemeListener = electron?.theme.onGetNativeTheme((nativeTheme) =>
-      dispatch(themeChanged(nativeTheme.shouldUseDarkColors ? 'dark' : 'light'))
+      dispatch(osThemeChangeDetected(nativeTheme.shouldUseDarkColors ? 'dark' : 'light'))
     )
 
     electron?.theme.getNativeTheme()

--- a/src/modals/SettingsModal/GeneralSettingsSection.tsx
+++ b/src/modals/SettingsModal/GeneralSettingsSection.tsx
@@ -27,7 +27,6 @@ import Toggle from '@/components/Inputs/Toggle'
 import HorizontalDivider from '@/components/PageComponents/HorizontalDivider'
 import PasswordConfirmation from '@/components/PasswordConfirmation'
 import { useAppDispatch, useAppSelector } from '@/hooks/redux'
-import useSwitchTheme from '@/hooks/useSwitchTheme'
 import CenteredModal from '@/modals/CenteredModal'
 import ModalPortal from '@/modals/ModalPortal'
 import {
@@ -36,6 +35,7 @@ import {
   passwordRequirementToggled,
   walletLockTimeChanged
 } from '@/storage/app-state/slices/settingsSlice'
+import { switchTheme } from '@/storage/storage-utils/settingsStorageUtils'
 import { Language, ThemeType } from '@/types/settings'
 
 interface GeneralSettingsSectionProps {
@@ -58,7 +58,6 @@ const themeOptions = [
 const GeneralSettingsSection = ({ className }: GeneralSettingsSectionProps) => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const switchTheme = useSwitchTheme()
   const [isAuthenticated, { walletLockTimeInMinutes, discreetMode, passwordRequirement, language, theme }] =
     useAppSelector((s) => [!!s.activeWallet.mnemonic, s.settings])
 

--- a/src/storage/app-state/slices/settingsSlice.ts
+++ b/src/storage/app-state/slices/settingsSlice.ts
@@ -37,7 +37,7 @@ const settingsSlice = createSlice({
   name: sliceName,
   initialState,
   reducers: {
-    themeChanged: (state, action: PayloadAction<Settings['general']['theme']>) => {
+    themeSettingsChanged: (state, action: PayloadAction<Settings['general']['theme']>) => {
       state.theme = action.payload
     },
     discreetModeToggled: (state) => {
@@ -61,7 +61,7 @@ const settingsSlice = createSlice({
 
 export const {
   generalSettingsMigrated,
-  themeChanged,
+  themeSettingsChanged,
   discreetModeToggled,
   passwordRequirementToggled,
   devToolsToggled,
@@ -74,7 +74,7 @@ export const settingsListenerMiddleware = createListenerMiddleware()
 // When the settings change, store them in persistent storage
 settingsListenerMiddleware.startListening({
   matcher: isAnyOf(
-    themeChanged,
+    themeSettingsChanged,
     discreetModeToggled,
     passwordRequirementToggled,
     devToolsToggled,

--- a/src/storage/storage-utils/settingsStorageUtils.ts
+++ b/src/storage/storage-utils/settingsStorageUtils.ts
@@ -16,21 +16,15 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { useAppDispatch } from '@/hooks/redux'
-import { themeChanged } from '@/storage/app-state/slices/settingsSlice'
+import { themeSettingsChanged } from '@/storage/app-state/slices/settingsSlice'
+import { store } from '@/storage/app-state/store'
 import { ThemeType } from '@/types/settings'
 import { AlephiumWindow } from '@/types/window'
 
 const _window = window as unknown as AlephiumWindow
 const electron = _window.electron
 
-const useSwitchTheme = () => {
-  const dispatch = useAppDispatch()
-
-  return (theme: ThemeType) => {
-    electron?.theme.setNativeTheme(theme)
-    dispatch(themeChanged(theme))
-  }
+export const switchTheme = (theme: ThemeType) => {
+  electron?.theme.setNativeTheme(theme)
+  store.dispatch(themeSettingsChanged(theme))
 }
-
-export default useSwitchTheme


### PR DESCRIPTION
Closes #490

The bug was introduced when I migrated the general settings to Redux. When listening to OS theme changes, I was dispatching an action that would change the theme settings to either `light` or `dark` and store those settings in localStorage. Instead, I should have separated the theme settings into 2 settings: stored theme settings (`system | light | dark)` and "currently visible theme" (`light | dark`). Now, there are 2 actions:
- `osThemeChangeDetected` (triggered by the OS, can be `light` or `dark`), which sets the theme and doesn't store it in localStorage
- `themeSwitched` (triggered by the user, can be `system`, `light` or `dark`), which sets the theme and stores it in localStorage