### PR TITLE
Compatibility with node 1.7.1 exp 1.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "electron-updater": "^5.3.0"
       },
       "devDependencies": {
-        "@alephium/sdk": "0.5.0",
+        "@alephium/sdk": "0.6.1",
         "@alephium/walletconnect-provider": "0.2.1",
         "@alephium/web3": "0.5.2",
         "@electron/notarize": "^1.2.3",
@@ -97,9 +97,9 @@
       "license": "MIT"
     },
     "node_modules/@alephium/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-GcuaKU4TOUBeRy1UNvOpYPGjQ2zF2fY7mbHr6/wC28IkSbQgmAzEbIsc0y82w0opdkQZQRCk/hJeQmShuI6iIA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.6.1.tgz",
+      "integrity": "sha512-ewmio50Q7n/fRcAXM8eXm7XAycQOMd50JhbgVL/MhEl/QU3NvbsTMu4tAPOv0FqUJVQ+Wq/NugF+l6WHJ1JmvA==",
       "dev": true,
       "dependencies": {
         "base-x": "^4.0.0",
@@ -20249,9 +20249,9 @@
       "dev": true
     },
     "@alephium/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-GcuaKU4TOUBeRy1UNvOpYPGjQ2zF2fY7mbHr6/wC28IkSbQgmAzEbIsc0y82w0opdkQZQRCk/hJeQmShuI6iIA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@alephium/sdk/-/sdk-0.6.1.tgz",
+      "integrity": "sha512-ewmio50Q7n/fRcAXM8eXm7XAycQOMd50JhbgVL/MhEl/QU3NvbsTMu4tAPOv0FqUJVQ+Wq/NugF+l6WHJ1JmvA==",
       "dev": true,
       "requires": {
         "base-x": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "electron-updater": "^5.3.0"
   },
   "devDependencies": {
-    "@alephium/sdk": "0.5.0",
+    "@alephium/sdk": "0.6.1",
     "@alephium/walletconnect-provider": "0.2.1",
     "@alephium/web3": "0.5.2",
     "@electron/notarize": "^1.2.3",

--- a/src/components/Amount.tsx
+++ b/src/components/Amount.tsx
@@ -51,7 +51,7 @@ const Amount = ({
   let suffix = ''
 
   if (!discreetMode && value !== undefined) {
-    let amount = formatAmountForDisplay(value, fullPrecision, nbOfDecimalsToShow)
+    let amount = formatAmountForDisplay({ amount: value, fullPrecision, displayDecimals: nbOfDecimalsToShow })
     if (fadeDecimals && ['K', 'M', 'B', 'T'].some((char) => amount.endsWith(char))) {
       suffix = amount.slice(-1)
       amount = amount.slice(0, -1)

--- a/src/components/Inputs/AmountInput.tsx
+++ b/src/components/Inputs/AmountInput.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { convertSetToAlph, MIN_UTXO_SET_AMOUNT } from '@alephium/sdk'
+import { MIN_UTXO_SET_AMOUNT, toHumanReadableAmount } from '@alephium/sdk'
 import { ChangeEvent, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { useTheme } from 'styled-components'
@@ -36,8 +36,8 @@ const AmountInput = ({ className, availableAmount, ...props }: AmountInputProps)
   const { value, onChange, ...restProps } = props
   const { t } = useTranslation()
   const [amountValue, setAmountValue] = useState(value)
-  const availableAmountInAlph = convertSetToAlph(availableAmount)
-  const minAmountInAlph = convertSetToAlph(MIN_UTXO_SET_AMOUNT)
+  const availableAmountInAlph = toHumanReadableAmount(availableAmount)
+  const minAmountInAlph = toHumanReadableAmount(MIN_UTXO_SET_AMOUNT)
   const [error, setError] = useState('')
   const theme = useTheme()
 

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -88,7 +88,7 @@ const TransactionalInfo = ({
         </CellArrow>
         <TokenTimeInner>
           {label}
-          <HiddenLabel text={`${formatAmountForDisplay(BigInt(amount ?? 0))} ${token}`} />
+          <HiddenLabel text={`${formatAmountForDisplay({ amount: BigInt(amount ?? 0) })} ${token}`} />
           <TimeSince timestamp={tx.timestamp} faded />
         </TokenTimeInner>
       </CellTime>

--- a/src/contexts/addresses.tsx
+++ b/src/contexts/addresses.tsx
@@ -23,7 +23,7 @@ import {
   TOTAL_NUMBER_OF_GROUPS,
   Wallet
 } from '@alephium/sdk'
-import { AddressInfo, Transaction, UnconfirmedTransaction } from '@alephium/sdk/api/explorer'
+import { AddressInfo, MempoolTransaction, Transaction } from '@alephium/sdk/api/explorer'
 import { merge } from 'lodash'
 import { createContext, FC, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -242,15 +242,11 @@ export const AddressesContextProvider: FC<{ overrideContextValue?: PartialDeep<A
       for (const address of addressesToCheck) {
         try {
           console.log('🤷 Fetching unconfirmed txs for', address.hash)
-          const { data: txs } = await client.explorer.addresses.getAddressesAddressUnconfirmedTransactions(address.hash)
+          const { data: txs } = await client.explorer.addresses.getAddressesAddressMempoolTransactions(address.hash)
 
           txs.forEach((tx) => {
-            if (tx.type === 'Unconfirmed' && !address.transactions.pending.some((t: PendingTx) => t.txId === tx.hash)) {
-              const pendingTx = convertUnconfirmedTxToPendingTx(
-                tx as UnconfirmedTransaction,
-                address.hash,
-                currentNetwork
-              )
+            if (!address.transactions.pending.some((t: PendingTx) => t.txId === tx.hash)) {
+              const pendingTx = convertUnconfirmedTxToPendingTx(tx as MempoolTransaction, address.hash, currentNetwork)
 
               address.addPendingTransaction(pendingTx)
             }

--- a/src/contexts/walletconnect.tsx
+++ b/src/contexts/walletconnect.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { convertSetToAlph } from '@alephium/sdk'
+import { toHumanReadableAmount } from '@alephium/sdk'
 import { RelayMethod } from '@alephium/walletconnect-provider'
 import {
   ApiRequestArguments,
@@ -137,7 +137,7 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
         switch (request.method as RelayMethod) {
           case 'alph_signAndSubmitTransferTx': {
             const p = request.params as SignTransferTxParams
-            const alphAmount = convertSetToAlph(BigInt(p.destinations[0].attoAlphAmount))
+            const alphAmount = toHumanReadableAmount(BigInt(p.destinations[0].attoAlphAmount))
             const txData: TransferTxData = {
               fromAddress: getAddressByHash(p.signerAddress),
               toAddress: p.destinations[0].address,
@@ -152,7 +152,7 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
           case 'alph_signAndSubmitDeployContractTx': {
             const p = request.params as SignDeployContractTxParams
             const initialAlphAmount =
-              p.initialAttoAlphAmount !== undefined ? convertSetToAlph(BigInt(p.initialAttoAlphAmount)) : undefined
+              p.initialAttoAlphAmount !== undefined ? toHumanReadableAmount(BigInt(p.initialAttoAlphAmount)) : undefined
             const txData: DeployContractTxData = {
               fromAddress: getAddressByHash(p.signerAddress),
               bytecode: p.bytecode,
@@ -167,7 +167,8 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
           }
           case 'alph_signAndSubmitExecuteScriptTx': {
             const p = request.params as SignExecuteScriptTxParams
-            const alphAmount = p.attoAlphAmount !== undefined ? convertSetToAlph(BigInt(p.attoAlphAmount)) : undefined
+            const alphAmount =
+              p.attoAlphAmount !== undefined ? toHumanReadableAmount(BigInt(p.attoAlphAmount)) : undefined
             const txData: ScriptTxData = {
               fromAddress: getAddressByHash(p.signerAddress),
               bytecode: p.bytecode,

--- a/src/hooks/useGasSettings.tsx
+++ b/src/hooks/useGasSettings.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { convertAlphToSet, formatAmountForDisplay, MINIMAL_GAS_AMOUNT, MINIMAL_GAS_PRICE } from '@alephium/sdk'
+import { formatAmountForDisplay, fromHumanReadableAmount, MINIMAL_GAS_AMOUNT, MINIMAL_GAS_PRICE } from '@alephium/sdk'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -47,13 +47,13 @@ const useGasSettings = (initialGasAmount?: string, initialGasPrice?: string) => 
     let newPriceNumber
 
     try {
-      newPriceNumber = convertAlphToSet(newPrice || '0')
+      newPriceNumber = fromHumanReadableAmount(newPrice || '0')
 
       setGasPrice(newPrice)
       setGasPriceError(
         newPriceNumber && newPriceNumber < MINIMAL_GAS_PRICE
           ? t('Gas price must be greater than {{ amount }}', {
-              amount: formatAmountForDisplay(MINIMAL_GAS_PRICE, true)
+              amount: formatAmountForDisplay({ amount: MINIMAL_GAS_PRICE, fullPrecision: true })
             })
           : ''
       )

--- a/src/hooks/useTransactionInfo.tsx
+++ b/src/hooks/useTransactionInfo.tsx
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import {
-  calcTxAmountDeltaForAddress,
+  calcTxAmountsDeltaForAddress,
   getDirection,
   isConsolidationTx,
   TransactionDirection,
@@ -44,8 +44,8 @@ export const useTransactionInfo = (tx: TransactionVariant, addressHash: AddressH
     lockTime = tx.lockTime
   } else {
     outputs = tx.outputs ?? outputs
-    amount = calcTxAmountDeltaForAddress(tx, addressHash)
-    amount = amount < 0 ? amount * BigInt(-1) : amount
+    const { alph: alphAmount } = calcTxAmountsDeltaForAddress(tx, addressHash)
+    amount = alphAmount < 0 ? alphAmount * BigInt(-1) : alphAmount
 
     if (isConsolidationTx(tx)) {
       direction = 'out'

--- a/src/modals/SendModals/AlphAmountInfoBox.tsx
+++ b/src/modals/SendModals/AlphAmountInfoBox.tsx
@@ -35,7 +35,8 @@ const AlphAmountInfoBox = ({ amount, label, fullPrecision = false, ...props }: A
   return (
     <InfoBox label={label ?? t`Amount`} {...props}>
       <Amount>
-        {formatAmountForDisplay(amount, fullPrecision, !fullPrecision ? 7 : undefined)} <AlefSymbol />
+        {formatAmountForDisplay({ amount, fullPrecision, displayDecimals: !fullPrecision ? 7 : undefined })}{' '}
+        <AlefSymbol />
       </Amount>
     </InfoBox>
   )

--- a/src/modals/SendModals/GasSettingsExpandableSection.tsx
+++ b/src/modals/SendModals/GasSettingsExpandableSection.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { convertAlphToSet, formatAmountForDisplay } from '@alephium/sdk'
+import { formatAmountForDisplay, fromHumanReadableAmount } from '@alephium/sdk'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from 'styled-components'
 
@@ -51,9 +51,9 @@ const GasSettingsExpandableSection = ({
   const { t } = useTranslation()
   const theme = useTheme()
 
-  const expectedFeeInALPH = !!gasAmount && !!gasPrice && BigInt(gasAmount) * convertAlphToSet(gasPrice)
+  const expectedFeeInALPH = !!gasAmount && !!gasPrice && BigInt(gasAmount) * fromHumanReadableAmount(gasPrice)
 
-  const minimalGasPriceInALPH = formatAmountForDisplay(MINIMAL_GAS_PRICE, true)
+  const minimalGasPriceInALPH = formatAmountForDisplay({ amount: MINIMAL_GAS_PRICE, fullPrecision: true })
 
   return (
     <ToggleSection {...props} title={t`Gas`} onClick={onClearGasSettings} className={className}>

--- a/src/modals/SendModals/SendModalDeployContract.tsx
+++ b/src/modals/SendModals/SendModalDeployContract.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { convertAlphToSet } from '@alephium/sdk'
+import { fromHumanReadableAmount } from '@alephium/sdk'
 import { binToHex, contractIdFromAddress, SignDeployContractTxResult } from '@alephium/web3'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -53,7 +53,7 @@ const DeployContractTxModal = () => {
 
   const buildTransaction = async (client: Client, data: DeployContractTxData, context: TxContext) => {
     const initialAttoAlphAmount =
-      data.initialAlphAmount !== undefined ? convertAlphToSet(data.initialAlphAmount).toString() : undefined
+      data.initialAlphAmount !== undefined ? fromHumanReadableAmount(data.initialAlphAmount).toString() : undefined
     const response = await client.web3.contracts.postContractsUnsignedTxDeployContract({
       fromPublicKey: data.fromAddress.publicKey,
       bytecode: data.bytecode,
@@ -141,7 +141,7 @@ const DeployContractBuildTxModalContent = ({ data, onSubmit, onCancel }: DeployC
     !gasPriceError &&
     !gasAmountError &&
     !!bytecode &&
-    (!alphAmount || isAmountWithinRange(convertAlphToSet(alphAmount), fromAddress.availableBalance))
+    (!alphAmount || isAmountWithinRange(fromHumanReadableAmount(alphAmount), fromAddress.availableBalance))
 
   return (
     <>
@@ -181,7 +181,7 @@ const DeployContractBuildTxModalContent = ({ data, onSubmit, onCancel }: DeployC
             fromAddress,
             bytecode: bytecode ?? '',
             issueTokenAmount: issueTokenAmount || undefined,
-            initialAlphAmount: (alphAmount && convertAlphToSet(alphAmount).toString()) || undefined,
+            initialAlphAmount: (alphAmount && fromHumanReadableAmount(alphAmount).toString()) || undefined,
             gasAmount: gasAmount ? parseInt(gasAmount) : undefined,
             gasPrice
           })

--- a/src/modals/SendModals/SendModalScript.tsx
+++ b/src/modals/SendModals/SendModalScript.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { convertAlphToSet } from '@alephium/sdk'
+import { fromHumanReadableAmount } from '@alephium/sdk'
 import { SignExecuteScriptTxResult } from '@alephium/web3'
 import { useTranslation } from 'react-i18next'
 
@@ -105,7 +105,7 @@ const ScriptBuildTxModalContent = ({ data, onSubmit, onCancel }: ScriptBuildTxMo
     !gasPriceError &&
     !gasAmountError &&
     !!bytecode &&
-    (!alphAmount || isAmountWithinRange(convertAlphToSet(alphAmount), fromAddress.availableBalance))
+    (!alphAmount || isAmountWithinRange(fromHumanReadableAmount(alphAmount), fromAddress.availableBalance))
 
   return (
     <>
@@ -153,14 +153,15 @@ const buildTransaction = async (client: Client, txData: ScriptTxData, ctx: TxCon
   if (!txData.alphAmount) {
     txData.alphAmount = undefined
   }
-  const attoAlphAmount = txData.alphAmount !== undefined ? convertAlphToSet(txData.alphAmount).toString() : undefined
+  const attoAlphAmount =
+    txData.alphAmount !== undefined ? fromHumanReadableAmount(txData.alphAmount).toString() : undefined
   const response = await client.web3.contracts.postContractsUnsignedTxExecuteScript({
     fromPublicKey: txData.fromAddress.publicKey,
     bytecode: txData.bytecode,
     attoAlphAmount,
     tokens: undefined,
     gasAmount: txData.gasAmount,
-    gasPrice: txData.gasPrice ? convertAlphToSet(txData.gasPrice).toString() : undefined
+    gasPrice: txData.gasPrice ? fromHumanReadableAmount(txData.gasPrice).toString() : undefined
   })
   ctx.setUnsignedTransaction(response)
   ctx.setUnsignedTxId(response.txId)

--- a/src/modals/SendModals/SendModalTransfer.tsx
+++ b/src/modals/SendModals/SendModalTransfer.tsx
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { convertAlphToSet } from '@alephium/sdk'
+import { fromHumanReadableAmount } from '@alephium/sdk'
 import { SignTransferTxResult } from '@alephium/web3'
 import dayjs from 'dayjs'
 import { useState } from 'react'
@@ -134,7 +134,7 @@ const TransferBuildTxModalContent = ({ data, onSubmit, onCancel }: TransferBuild
     !toAddress.error &&
     !!alphAmount &&
     !lockTimeInPast &&
-    isAmountWithinRange(convertAlphToSet(alphAmount), fromAddress.availableBalance)
+    isAmountWithinRange(fromHumanReadableAmount(alphAmount), fromAddress.availableBalance)
 
   return (
     <>
@@ -198,7 +198,7 @@ const TransferBuildTxModalContent = ({ data, onSubmit, onCancel }: TransferBuild
 
 const buildTransaction = async (client: Client, transactionData: TransferTxData, context: TxContext) => {
   const { fromAddress, toAddress, alphAmount, gasAmount, gasPrice, lockTime } = transactionData
-  const amountInSet = convertAlphToSet(alphAmount)
+  const amountInSet = fromHumanReadableAmount(alphAmount)
   const sweep = amountInSet === fromAddress.availableBalance
 
   context.setIsSweeping(sweep)
@@ -215,7 +215,7 @@ const buildTransaction = async (client: Client, transactionData: TransferTxData,
       amountInSet.toString(),
       lockTime ? lockTime.getTime() : undefined,
       gasAmount ? gasAmount : undefined,
-      gasPrice ? convertAlphToSet(gasPrice).toString() : undefined
+      gasPrice ? fromHumanReadableAmount(gasPrice).toString() : undefined
     )
     context.setUnsignedTransaction(data)
     context.setUnsignedTxId(data.txId)
@@ -251,7 +251,7 @@ const handleSend = async (client: Client, transactionData: TransferTxData, conte
         toAddress,
         'transfer',
         context.currentNetwork,
-        convertAlphToSet(alphAmount),
+        fromHumanReadableAmount(alphAmount),
         lockTime
       )
 

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -89,15 +89,23 @@ describe('Settings migration', () => {
           explorerApiHost: 'https://backend-v18.mainnet.alephium.org',
           explorerUrl: 'https://explorer-v18.mainnet.alephium.org'
         }
+      },
+      {
+        network: {
+          networkId: 0,
+          nodeHost: 'https://wallet-v16.mainnet.alephium.org',
+          explorerApiHost: 'https://backend-v112.mainnet.alephium.org',
+          explorerUrl: 'https://explorer.alephium.org'
+        }
       }
     ]
 
     for (const settings of mainnetSettings) {
       localStorage.setItem('settings', JSON.stringify(settings))
       const migratedSettings = migrateDeprecatedSettings()
-      expect(migratedSettings.network.nodeHost).toBe('https://wallet-v16.mainnet.alephium.org')
-      expect(migratedSettings.network.explorerApiHost).toBe('https://backend-v112.mainnet.alephium.org')
-      expect(migratedSettings.network.explorerUrl).toBe('https://explorer.alephium.org')
+      expect(migratedSettings.network.nodeHost).toBe(networkEndpoints.mainnet.nodeHost)
+      expect(migratedSettings.network.explorerApiHost).toBe(networkEndpoints.mainnet.explorerApiHost)
+      expect(migratedSettings.network.explorerUrl).toBe(networkEndpoints.mainnet.explorerUrl)
       expect(migratedSettings.network.networkId).toBe(0)
     }
 
@@ -117,15 +125,23 @@ describe('Settings migration', () => {
           explorerApiHost: 'https://backend-v18.testnet.alephium.org',
           explorerUrl: 'https://explorer-v18.testnet.alephium.org'
         }
+      },
+      {
+        network: {
+          networkId: 1,
+          nodeHost: 'https://wallet-v16.testnet.alephium.org',
+          explorerApiHost: 'https://backend-v112.testnet.alephium.org',
+          explorerUrl: 'https://explorer.testnet.alephium.org'
+        }
       }
     ]
 
     for (const settings of testnetSettings) {
       localStorage.setItem('settings', JSON.stringify(settings))
       const migratedSettings = migrateDeprecatedSettings()
-      expect(migratedSettings.network.nodeHost).toBe('https://wallet-v16.testnet.alephium.org')
-      expect(migratedSettings.network.explorerApiHost).toBe('https://backend-v112.testnet.alephium.org')
-      expect(migratedSettings.network.explorerUrl).toBe('https://explorer.testnet.alephium.org')
+      expect(migratedSettings.network.nodeHost).toBe(networkEndpoints.testnet.nodeHost)
+      expect(migratedSettings.network.explorerApiHost).toBe(networkEndpoints.testnet.explorerApiHost)
+      expect(migratedSettings.network.explorerUrl).toBe(networkEndpoints.testnet.explorerUrl)
       expect(migratedSettings.network.networkId).toBe(1)
     }
   })

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -46,14 +46,14 @@ type DeprecatedNetworkSettings = Settings['network']
 export const networkEndpoints: Record<Exclude<NetworkName, 'custom'>, Settings['network']> = {
   mainnet: {
     networkId: 0,
-    nodeHost: 'https://wallet-v16.mainnet.alephium.org',
-    explorerApiHost: 'https://backend-v112.mainnet.alephium.org',
+    nodeHost: 'https://wallet-v17.mainnet.alephium.org',
+    explorerApiHost: 'https://backend-v113.mainnet.alephium.org',
     explorerUrl: 'https://explorer.alephium.org'
   },
   testnet: {
     networkId: 1,
-    nodeHost: 'https://wallet-v16.testnet.alephium.org',
-    explorerApiHost: 'https://backend-v112.testnet.alephium.org',
+    nodeHost: 'https://wallet-v17.testnet.alephium.org',
+    explorerApiHost: 'https://backend-v113.testnet.alephium.org',
     explorerUrl: 'https://explorer.testnet.alephium.org'
   },
   localhost: {
@@ -117,14 +117,16 @@ export const migrateDeprecatedSettings = (): Settings => {
 
   if (
     settings.network.explorerApiHost === 'https://mainnet-backend.alephium.org' ||
-    settings.network.explorerApiHost === 'https://backend-v18.mainnet.alephium.org'
+    settings.network.explorerApiHost === 'https://backend-v18.mainnet.alephium.org' ||
+    settings.network.explorerApiHost === 'https://backend-v112.mainnet.alephium.org'
   ) {
-    migratedSettings.network.explorerApiHost = 'https://backend-v112.mainnet.alephium.org'
+    migratedSettings.network.explorerApiHost = networkEndpoints.mainnet.explorerApiHost
   } else if (
     settings.network.explorerApiHost === 'https://testnet-backend.alephium.org' ||
-    settings.network.explorerApiHost === 'https://backend-v18.testnet.alephium.org'
+    settings.network.explorerApiHost === 'https://backend-v18.testnet.alephium.org' ||
+    settings.network.explorerApiHost === 'https://backend-v112.testnet.alephium.org'
   ) {
-    migratedSettings.network.explorerApiHost = 'https://backend-v112.testnet.alephium.org'
+    migratedSettings.network.explorerApiHost = networkEndpoints.testnet.explorerApiHost
   }
 
   if (settings.network.explorerUrl === 'https://explorer-v18.mainnet.alephium.org') {
@@ -138,14 +140,16 @@ export const migrateDeprecatedSettings = (): Settings => {
 
   if (
     settings.network.nodeHost === 'https://mainnet-wallet.alephium.org' ||
-    settings.network.nodeHost === 'https://wallet-v18.mainnet.alephium.org'
+    settings.network.nodeHost === 'https://wallet-v18.mainnet.alephium.org' ||
+    settings.network.nodeHost === 'https://wallet-v16.mainnet.alephium.org'
   ) {
-    migratedSettings.network.nodeHost = 'https://wallet-v16.mainnet.alephium.org'
+    migratedSettings.network.nodeHost = networkEndpoints.mainnet.nodeHost
   } else if (
     settings.network.nodeHost === 'https://testnet-wallet.alephium.org' ||
-    settings.network.nodeHost === 'https://wallet-v18.testnet.alephium.org'
+    settings.network.nodeHost === 'https://wallet-v18.testnet.alephium.org' ||
+    settings.network.nodeHost === 'https://wallet-v16.testnet.alephium.org'
   ) {
-    migratedSettings.network.nodeHost = 'https://wallet-v16.testnet.alephium.org'
+    migratedSettings.network.nodeHost = networkEndpoints.testnet.nodeHost
   }
 
   const newSettings = merge({}, defaultSettings, migratedSettings)


### PR DESCRIPTION
It came to my attention today that we are ready to [publish an update](https://github.com/alephium/docs/pull/163) to our [public services doc page](https://docs.alephium.org/dapps/public-services) which will deprecate the [network endpoints](https://github.com/alephium/desktop-wallet/blob/master/src/utils/settings.ts#L49-L56.) that our latest desktop wallet version uses. When the docs PR gets merged, it will be weird to not also provide a desktop wallet version that uses our documented endpoints. Thus, I made this PR.

This PR updates the version of our SDK to `0.6.1` which uses the schemas from node `1.7.1` and explorer backend `1.13.0` and fixes all [breaking changes](https://github.com/alephium/js-sdk/releases/tag/v0.6.1).

Since the endpoints mention in the doc PR are [not yet accessible](https://github.com/alephium/docs/pull/163#discussion_r1126594775), I have not yet tested my changes.

Once this PR is merged, we can release `1.5.3` which will essentially make the wallet compatible with the Leman upgrade, even before v2.0 comes out.

Closes https://github.com/alephium/desktop-wallet/issues/549

<details><summary>(see screenshot that proves above fix)</summary>

<img width="587" alt="image" src="https://user-images.githubusercontent.com/1579899/223382918-00dd2a58-9ef7-4001-a81a-b7297977727f.png">

</details>