### PR TITLE
Include `default` keyType for chain account for walletconnect

### DIFF
--- a/src/modals/WalletConnectModal.tsx
+++ b/src/modals/WalletConnectModal.tsx
@@ -105,7 +105,7 @@ const WalletConnectModal = ({ onClose, onConnect }: Props) => {
         setErrorState(t`Invalid address group for the WallectConnect connection`)
       }
 
-      return [`${formatChain(chain.networkId, chain.chainGroup)}:${address.publicKey}`]
+      return [`${formatChain(chain.networkId, chain.chainGroup)}:${address.publicKey}/default`]
     },
     [setErrorState, t]
   )


### PR DESCRIPTION
This is in relation to https://github.com/alephium/alephium-web3-react/issues/10

`keyType` is required in the wallet connect provider as of https://github.com/alephium/walletconnect/commit/8629df4a67473d945ebdbf5ef798057d60ab40f4#diff-e0e6d91455eef50c5793e300039e5cdc7e6d372707172b639564495e4fa0a2f3R353

As far as I can see different key types aren't supported in the desktop wallet yet so send through `default` for now, or correct me if this is wrong 👍 

Also note I think `formatAccount` https://github.com/alephium/walletconnect/commit/8629df4a67473d945ebdbf5ef798057d60ab40f4#diff-e0e6d91455eef50c5793e300039e5cdc7e6d372707172b639564495e4fa0a2f3R346 might need to use a slash for the keytype separator otherwise walletconnect complains about improper formatting:

![image](https://user-images.githubusercontent.com/29697678/224891202-166ef8b6-eb44-4714-9c25-b4d12a84484d.png)

