### PR TITLE
[v2.0] Improve display of unknown tokens throughout the app

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -354,5 +354,9 @@
   "Change wallet name": "Change wallet name",
   "Could not save new wallet name.": "Could not save new wallet name.",
   "Wallet name updated to: {{ newWalletName }}": "Wallet name updated to: {{ newWalletName }}",
-  "Shortcuts": "Shortcuts"
+  "Shortcuts": "Shortcuts",
+  "Raw amount": "Raw amount",
+  "Unknown token": "Unknown token",
+  "Unknown tokens": "Unknown tokens",
+  "Copy token hash": "Copy token hash"
 }

--- a/src/components/AddressBadge.tsx
+++ b/src/components/AddressBadge.tsx
@@ -20,10 +20,10 @@ import { ComponentPropsWithoutRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
-import AddressEllipsed from '@/components/AddressEllipsed'
 import Badge from '@/components/Badge'
 import ClipboardButton from '@/components/Buttons/ClipboardButton'
 import DotIcon from '@/components/DotIcon'
+import HashEllipsed from '@/components/HashEllipsed'
 import { useAppSelector } from '@/hooks/redux'
 import { selectAddressByHash } from '@/storage/addresses/addressesSelectors'
 import { AddressHash } from '@/types/addresses'
@@ -51,12 +51,12 @@ const AddressBadge = ({
   const address = useAppSelector((state) => selectAddressByHash(state, addressHash))
   const isPassphraseUsed = useAppSelector((state) => state.activeWallet.isPassphraseUsed)
 
-  if (!address) return <AddressEllipsed addressHash={addressHash} />
+  if (!address) return <HashEllipsed hash={addressHash} />
 
   return showHashWhenNoLabel && !address.label ? (
     <Hash className={className}>
       {!isPassphraseUsed && address.isDefault && !hideStar && <Star color={address.color}>★</Star>}
-      <AddressEllipsed addressHash={address.hash} disableA11y={disableA11y} />
+      <HashEllipsed hash={address.hash} disableA11y={disableA11y} />
     </Hash>
   ) : (
     <ClipboardButton textToCopy={address.hash} tooltip={t`Copy address`} disableA11y={disableA11y}>

--- a/src/components/AddressRow.tsx
+++ b/src/components/AddressRow.tsx
@@ -18,8 +18,8 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import styled from 'styled-components'
 
-import AddressEllipsed from '@/components/AddressEllipsed'
 import DotIcon from '@/components/DotIcon'
+import HashEllipsed from '@/components/HashEllipsed'
 import { TableRow } from '@/components/Table'
 import { Address } from '@/types/addresses'
 
@@ -46,11 +46,11 @@ const AddressRow: FC<AddressRowProps> = ({ address, disableAddressCopy, onClick,
       {address.label ? (
         <Column>
           <Label>{address.label}</Label>
-          <AddressEllipsedStyled addressHash={address.hash} disableCopy={disableAddressCopy} />
+          <HashEllipsedStyled hash={address.hash} disableCopy={disableAddressCopy} />
         </Column>
       ) : (
         <Label>
-          <AddressEllipsed addressHash={address.hash} disableCopy={disableAddressCopy} />
+          <HashEllipsed hash={address.hash} disableCopy={disableAddressCopy} />
         </Label>
       )}
       {children}
@@ -78,7 +78,7 @@ const Label = styled.div`
   width: 200px;
 `
 
-const AddressEllipsedStyled = styled(AddressEllipsed)`
+const HashEllipsedStyled = styled(HashEllipsed)`
   color: ${({ theme }) => theme.font.tertiary};
   font-size: 11px;
   max-width: 100px;

--- a/src/components/Amount.tsx
+++ b/src/components/Amount.tsx
@@ -32,6 +32,7 @@ interface AmountProps {
   color?: string
   tabIndex?: number
   suffix?: string
+  isUnknownToken?: boolean
   className?: string
 }
 
@@ -45,7 +46,8 @@ const Amount = ({
   color,
   nbOfDecimalsToShow,
   suffix,
-  tabIndex
+  tabIndex,
+  isUnknownToken
 }: AmountProps) => {
   const { discreetMode } = useAppSelector((state) => state.settings)
 
@@ -58,6 +60,8 @@ const Amount = ({
       value !== undefined
         ? isFiat && typeof value === 'number'
           ? formatFiatAmountForDisplay(value)
+          : isUnknownToken
+          ? value.toString()
           : formatAmountForDisplay({
               amount: value as bigint,
               amountDecimals: decimals,
@@ -85,17 +89,19 @@ const Amount = ({
         fadeDecimals ? (
           <>
             <span>{integralPart}</span>
-            <Decimals>.{fractionalPart}</Decimals>
+            {fractionalPart && <Decimals>.{fractionalPart}</Decimals>}
             {quantitySymbol && <span>{quantitySymbol}</span>}
           </>
-        ) : (
+        ) : fractionalPart ? (
           `${integralPart}.${fractionalPart}`
+        ) : (
+          integralPart
         )
       ) : (
         '-'
       )}
 
-      {suffix && suffix !== 'ALPH' ? ` ${suffix}` : <AlefSymbol color={color} />}
+      {!isUnknownToken && (suffix && suffix !== 'ALPH' ? ` ${suffix}` : <AlefSymbol color={color} />)}
     </span>
   )
 }

--- a/src/components/AssetBadge.tsx
+++ b/src/components/AssetBadge.tsx
@@ -25,18 +25,17 @@ import { Asset } from '@/types/assets'
 
 interface AssetBadgeProps {
   assetId: Asset['id']
+  simple?: boolean
   className?: string
 }
 
-const AssetBadge = ({ assetId, className }: AssetBadgeProps) => {
-  const assetInfo = useAppSelector((state) => selectAssetInfoById(state, assetId))
-
-  if (!assetInfo) return null
+const AssetBadge = ({ assetId, simple, className }: AssetBadgeProps) => {
+  const assetInfo = useAppSelector((state) => selectAssetInfoById(state, assetId)) ?? { id: assetId, symbol: undefined }
 
   return (
     <div className={className}>
       <AssetLogo asset={assetInfo} size={20} />
-      <AssetSymbol>{assetInfo.symbol}</AssetSymbol>
+      {!simple && assetInfo.symbol && <AssetSymbol>{assetInfo.symbol}</AssetSymbol>}
     </div>
   )
 }

--- a/src/components/AssetBadge.tsx
+++ b/src/components/AssetBadge.tsx
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { TooltipWrapper } from 'react-tooltip'
 import styled from 'styled-components'
 
 import AssetLogo from '@/components/AssetLogo'
@@ -30,12 +31,18 @@ interface AssetBadgeProps {
 }
 
 const AssetBadge = ({ assetId, simple, className }: AssetBadgeProps) => {
-  const assetInfo = useAppSelector((state) => selectAssetInfoById(state, assetId)) ?? { id: assetId, symbol: undefined }
+  const assetInfo = useAppSelector((state) => selectAssetInfoById(state, assetId)) ?? {
+    id: assetId,
+    symbol: undefined,
+    name: undefined
+  }
 
   return (
     <div className={className}>
-      <AssetLogo asset={assetInfo} size={20} />
-      {!simple && assetInfo.symbol && <AssetSymbol>{assetInfo.symbol}</AssetSymbol>}
+      <TooltipWrapper content={assetInfo.name ?? assetId}>
+        <AssetLogo asset={assetInfo} size={20} />
+        {!simple && assetInfo.symbol && <AssetSymbol>{assetInfo.symbol}</AssetSymbol>}
+      </TooltipWrapper>
     </div>
   )
 }

--- a/src/components/AssetLogo.tsx
+++ b/src/components/AssetLogo.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { ALPH, TokenInfo } from '@alephium/token-list'
+import { BoxSelect } from 'lucide-react'
 import styled, { css } from 'styled-components'
 
 import AlephiumLogoSVG from '@/images/alephium_logo_monochrome.svg'
@@ -34,7 +35,7 @@ const AssetLogo = ({ asset, className }: AssetLogoProps) => (
     ) : asset.id === ALPH.id ? (
       <LogoImage src={AlephiumLogoSVG} />
     ) : (
-      '?'
+      <BoxSelect size={12} />
     )}
   </div>
 )

--- a/src/components/AssetLogo.tsx
+++ b/src/components/AssetLogo.tsx
@@ -29,7 +29,13 @@ interface AssetLogoProps {
 
 const AssetLogo = ({ asset, className }: AssetLogoProps) => (
   <div className={className}>
-    <LogoImage src={asset.logoURI ?? AlephiumLogoSVG} />
+    {asset.logoURI ? (
+      <LogoImage src={asset.logoURI} />
+    ) : asset.id === ALPH.id ? (
+      <LogoImage src={AlephiumLogoSVG} />
+    ) : (
+      '?'
+    )}
   </div>
 )
 
@@ -42,12 +48,16 @@ export default styled(AssetLogo)`
   border-radius: ${({ size }) => size}px;
   flex-shrink: 0;
 
-  ${({ asset }) =>
-    asset.id === ALPH.id &&
-    css`
-      padding: 5px;
-      background: linear-gradient(218.53deg, #0075ff 9.58%, #d340f8 86.74%);
-    `}
+  ${({ asset, theme }) =>
+    asset.id === ALPH.id
+      ? css`
+          padding: 5px;
+          background: linear-gradient(218.53deg, #0075ff 9.58%, #d340f8 86.74%);
+        `
+      : !asset.logoURI &&
+        css`
+          background: ${theme.bg.tertiary};
+        `}
 `
 
 const LogoImage = styled.img`

--- a/src/components/AssetLogo.tsx
+++ b/src/components/AssetLogo.tsx
@@ -17,7 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { ALPH, TokenInfo } from '@alephium/token-list'
-import { BoxSelect } from 'lucide-react'
+import { Ghost } from 'lucide-react'
 import styled, { css } from 'styled-components'
 
 import AlephiumLogoSVG from '@/images/alephium_logo_monochrome.svg'
@@ -28,14 +28,14 @@ interface AssetLogoProps {
   className?: string
 }
 
-const AssetLogo = ({ asset, className }: AssetLogoProps) => (
+const AssetLogo = ({ asset, size, className }: AssetLogoProps) => (
   <div className={className}>
     {asset.logoURI ? (
       <LogoImage src={asset.logoURI} />
     ) : asset.id === ALPH.id ? (
       <LogoImage src={AlephiumLogoSVG} />
     ) : (
-      <BoxSelect size={12} />
+      <Ghost size={size * 0.7} />
     )}
   </div>
 )

--- a/src/components/HashEllipsed.tsx
+++ b/src/components/HashEllipsed.tsx
@@ -22,36 +22,42 @@ import styled from 'styled-components'
 
 import ClipboardButton from '@/components/Buttons/ClipboardButton'
 import Ellipsed from '@/components/Ellipsed'
-import { AddressHash } from '@/types/addresses'
 
-interface AddressEllipsedProps extends HTMLAttributes<HTMLDivElement> {
-  addressHash: AddressHash
+interface HashEllipsedProps extends HTMLAttributes<HTMLDivElement> {
+  hash: string
+  tooltipText?: string
   disableA11y?: boolean
   disableCopy?: boolean
   className?: string
 }
 
-const AddressEllipsed = ({
-  addressHash,
+const HashEllipsed = ({
+  hash,
   disableA11y = false,
   disableCopy = false,
+  tooltipText,
   className,
   ...props
-}: AddressEllipsedProps) => {
+}: HashEllipsedProps) => {
   const { t } = useTranslation()
 
   return disableCopy ? (
     <Container className={className}>
-      <Ellipsed text={addressHash} {...props} />
+      <Ellipsed text={hash} {...props} />
     </Container>
   ) : (
-    <ClipboardButton textToCopy={addressHash} tooltip={t`Copy address`} disableA11y={disableA11y} className={className}>
-      <Ellipsed text={addressHash} {...props} />
+    <ClipboardButton
+      textToCopy={hash}
+      tooltip={tooltipText ?? t`Copy address`}
+      disableA11y={disableA11y}
+      className={className}
+    >
+      <Ellipsed text={hash} {...props} />
     </ClipboardButton>
   )
 }
 
-export default AddressEllipsed
+export default HashEllipsed
 
 const Container = styled.div`
   display: flex;

--- a/src/components/Inputs/AddressSelect.tsx
+++ b/src/components/Inputs/AddressSelect.tsx
@@ -22,8 +22,8 @@ import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
 import AddressBadge from '@/components/AddressBadge'
-import AddressEllipsed from '@/components/AddressEllipsed'
 import Amount from '@/components/Amount'
+import HashEllipsed from '@/components/HashEllipsed'
 import { inputDefaultStyle, InputLabel, InputProps } from '@/components/Inputs'
 import { MoreIcon, SelectContainer, SelectOption, SelectOptionsModal } from '@/components/Inputs/Select'
 import SelectOptionItemContent from '@/components/Inputs/SelectOptionItemContent'
@@ -121,7 +121,7 @@ function AddressSelect({
         )}
         <ClickableInput type="button" className={className} disabled={disabled} id={id} simpleMode={simpleMode}>
           <AddressBadge addressHash={address.hash} truncate showHashWhenNoLabel />
-          {!!address.label && !simpleMode && <AddressEllipsed addressHash={address.hash} />}
+          {!!address.label && !simpleMode && <HashEllipsed hash={address.hash} />}
         </ClickableInput>
       </AddressSelectContainer>
       <ModalPortal>

--- a/src/components/Inputs/SelectOptionItemContent.tsx
+++ b/src/components/Inputs/SelectOptionItemContent.tsx
@@ -46,5 +46,5 @@ const OptionItemContentLeft = styled.div`
 const OptionItemContentRight = styled.div`
   margin-left: auto;
   color: ${({ theme }) => theme.font.secondary};
-  max-width: 120px;
+  max-width: 200px;
 `

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -18,6 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { formatAmountForDisplay, isConsolidationTx } from '@alephium/sdk'
 import { Transaction } from '@alephium/sdk/api/explorer'
+import { partition } from 'lodash'
 import { ArrowRight as ArrowRightIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
@@ -76,6 +77,8 @@ const TransactionalInfo = ({
 
   const amountSign = showInternalInflows && infoType === 'move' && !isPending && !isConsolidationTx(tx) ? '- ' : sign
 
+  const [knownAssets, unknownAssets] = partition(assets, (asset) => !!asset.symbol)
+
   return (
     <div className={className}>
       <CellTime>
@@ -86,7 +89,7 @@ const TransactionalInfo = ({
         </CellArrow>
         <AssetTime>
           {label}
-          {assets.map(({ id, amount, decimals, symbol }) => (
+          {knownAssets.map(({ id, amount, decimals, symbol }) => (
             <HiddenLabel key={id} text={`${formatAmountForDisplay({ amount, amountDecimals: decimals })} ${symbol}`} />
           ))}
           <TimeSince timestamp={tx.timestamp} faded />
@@ -94,9 +97,10 @@ const TransactionalInfo = ({
       </CellTime>
       <CellAssetBadges compact={compact}>
         <AssetBadges>
-          {assets.map(({ id }) => (
+          {knownAssets.map(({ id }) => (
             <AssetBadge assetId={id} key={id} />
           ))}
+          {unknownAssets.length > 0 && <UnknownTokenNumber>(+{unknownAssets.length})</UnknownTokenNumber>}
         </AssetBadges>
       </CellAssetBadges>
       {!showInternalInflows && (
@@ -147,7 +151,7 @@ const TransactionalInfo = ({
         </DirectionalAddress>
       </CellAddress>
       <TableCellAmount aria-hidden="true" color={amountTextColor}>
-        {assets.map(({ id, amount, decimals, symbol }) => (
+        {knownAssets.map(({ id, amount, decimals, symbol }) => (
           <AmountContainer key={id}>
             {lockTime && lockTime > new Date() && <LockStyled unlockAt={lockTime} />}
             <div>
@@ -257,4 +261,9 @@ const AssetBadges = styled.div`
   gap: 20px;
   row-gap: 10px;
   flex-wrap: wrap;
+  align-items: center;
+`
+
+const UnknownTokenNumber = styled.div`
+  color: ${({ theme }) => theme.font.tertiary};
 `

--- a/src/components/TransactionalInfo.tsx
+++ b/src/components/TransactionalInfo.tsx
@@ -92,15 +92,15 @@ const TransactionalInfo = ({
           {knownAssets.map(({ id, amount, decimals, symbol }) => (
             <HiddenLabel key={id} text={`${formatAmountForDisplay({ amount, amountDecimals: decimals })} ${symbol}`} />
           ))}
+          {unknownAssets.length > 0 && <HiddenLabel text={` + ${unknownAssets} ${t('Unknown tokens')}`} />}
           <TimeSince timestamp={tx.timestamp} faded />
         </AssetTime>
       </CellTime>
       <CellAssetBadges compact={compact}>
         <AssetBadges>
-          {knownAssets.map(({ id }) => (
-            <AssetBadge assetId={id} key={id} />
+          {assets.map(({ id }) => (
+            <AssetBadge assetId={id} simple key={id} />
           ))}
-          {unknownAssets.length > 0 && <UnknownTokenNumber>(+{unknownAssets.length})</UnknownTokenNumber>}
         </AssetBadges>
       </CellAssetBadges>
       {!showInternalInflows && (
@@ -262,8 +262,4 @@ const AssetBadges = styled.div`
   row-gap: 10px;
   flex-wrap: wrap;
   align-items: center;
-`
-
-const UnknownTokenNumber = styled.div`
-  color: ${({ theme }) => theme.font.tertiary};
 `

--- a/src/hooks/useTransactionInfo.tsx
+++ b/src/hooks/useTransactionInfo.tsx
@@ -29,12 +29,24 @@ import { ALPH } from '@alephium/token-list'
 import { useAppSelector } from '@/hooks/redux'
 import { selectAllAddresses } from '@/storage/addresses/addressesSelectors'
 import { AddressHash } from '@/types/addresses'
-import { AssetAmount } from '@/types/assets'
+import { AssetAmount, TransactionInfoAsset } from '@/types/assets'
 import { AddressTransaction } from '@/types/transactions'
 import { convertToPositive } from '@/utils/misc'
 import { hasOnlyOutputsWith, isPendingTx } from '@/utils/transactions'
 
-export const useTransactionInfo = (tx: AddressTransaction, addressHash: AddressHash, showInternalInflows?: boolean) => {
+interface TransactionInfo {
+  assets: TransactionInfoAsset[]
+  direction: TransactionDirection
+  infoType: TransactionInfoType
+  outputs: Output[]
+  lockTime?: Date
+}
+
+export const useTransactionInfo = (
+  tx: AddressTransaction,
+  addressHash: AddressHash,
+  showInternalInflows?: boolean
+): TransactionInfo => {
   const addresses = useAppSelector(selectAllAddresses)
   const assetsInfo = useAppSelector((state) => state.assetsInfo.entities)
 

--- a/src/modals/AddressDetailsModal.tsx
+++ b/src/modals/AddressDetailsModal.tsx
@@ -22,10 +22,10 @@ import { useTranslation } from 'react-i18next'
 import QRCode from 'react-qr-code'
 import styled, { useTheme } from 'styled-components'
 
-import AddressEllipsed from '@/components/AddressEllipsed'
 import Box from '@/components/Box'
 import Button from '@/components/Button'
 import DotIcon from '@/components/DotIcon'
+import HashEllipsed from '@/components/HashEllipsed'
 import TransactionList from '@/components/TransactionList'
 import { useAppSelector } from '@/hooks/redux'
 import AddressOptionsModal from '@/modals/AddressOptionsModal'
@@ -72,9 +72,9 @@ const AddressDetailsModal = ({ addressHash, onClose }: AddressDetailsModalProps)
               )}
             </AddressColor>
             <Column>
-              <Label>{address.label || <AddressEllipsedStyled addressHash={address.hash} />}</Label>
+              <Label>{address.label || <HashEllipsedStyled hash={address.hash} />}</Label>
               <Subtitle>
-                {address.label && <Hash addressHash={address.hash} />}
+                {address.label && <Hash hash={address.hash} />}
                 <Group>
                   {t('Group')} {address.group}
                 </Group>
@@ -166,11 +166,11 @@ const Label = styled.div`
   font-weight: var(--fontWeight-semiBold);
 `
 
-const AddressEllipsedStyled = styled(AddressEllipsed)`
+const HashEllipsedStyled = styled(HashEllipsed)`
   max-width: 300px;
 `
 
-const Hash = styled(AddressEllipsed)`
+const Hash = styled(HashEllipsed)`
   color: ${({ theme }) => theme.font.secondary};
   font-size: 16px;
   max-width: 250px;

--- a/src/modals/ModalPortal.tsx
+++ b/src/modals/ModalPortal.tsx
@@ -19,6 +19,15 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { AnimatePresence } from 'framer-motion'
 import { createPortal } from 'react-dom'
 
-const ModalPortal: FC = ({ children }) => createPortal(<AnimatePresence>{children}</AnimatePresence>, document.body)
+import Tooltips from '@/components/Tooltips'
+
+const ModalPortal: FC = ({ children }) =>
+  createPortal(
+    <>
+      <AnimatePresence>{children}</AnimatePresence>
+      <Tooltips />
+    </>,
+    document.body
+  )
 
 export default ModalPortal

--- a/src/modals/SendModals/AddressInputs.tsx
+++ b/src/modals/SendModals/AddressInputs.tsx
@@ -22,8 +22,8 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import AddressEllipsed from '@/components/AddressEllipsed'
 import Box from '@/components/Box'
+import HashEllipsed from '@/components/HashEllipsed'
 import { inputStyling } from '@/components/Inputs'
 import AddressSelect from '@/components/Inputs/AddressSelect'
 import Input from '@/components/Inputs/Input'
@@ -134,7 +134,7 @@ const AddressInputs = ({
           {isContactVisible && (
             <ContactRow onClick={handleFocus}>
               <Truncate>{contact.name}</Truncate>
-              <AddressEllipsedStyled addressHash={contact.address} disableA11y />
+              <HashEllipsedStyled hash={contact.address} disableA11y />
             </ContactRow>
           )}
         </AddressToInput>
@@ -152,7 +152,7 @@ const AddressInputs = ({
             optionRender={(contact) => (
               <SelectOptionItemContent
                 ContentLeft={<Name>{contact.label}</Name>}
-                ContentRight={<AddressEllipsedStyled addressHash={contact.value} />}
+                ContentRight={<HashEllipsedStyled hash={contact.value} />}
               />
             )}
           />
@@ -169,7 +169,7 @@ const Name = styled(Truncate)`
   max-width: 200px;
 `
 
-const AddressEllipsedStyled = styled(AddressEllipsed)`
+const HashEllipsedStyled = styled(HashEllipsed)`
   margin-left: auto;
   color: ${({ theme }) => theme.font.secondary};
   max-width: 120px;

--- a/src/modals/SendModals/AssetAmountsInput.tsx
+++ b/src/modals/SendModals/AssetAmountsInput.tsx
@@ -28,6 +28,7 @@ import Amount from '@/components/Amount'
 import AssetLogo from '@/components/AssetLogo'
 import Box from '@/components/Box'
 import Button from '@/components/Button'
+import HashEllipsed from '@/components/HashEllipsed'
 import { inputDefaultStyle, InputLabel, InputProps } from '@/components/Inputs'
 import Input from '@/components/Inputs/Input'
 import { SelectContainer, SelectOption, SelectOptionsModal } from '@/components/Inputs/Select'
@@ -65,7 +66,7 @@ const AssetAmountsInput = ({ address, assetAmounts, onAssetAmountsChange, classN
   const disabled = remainingAvailableAssets.length === 0
   const availableAssetOptions: SelectOption<Asset['id']>[] = remainingAvailableAssets.map((asset) => ({
     value: asset.id,
-    label: asset.name
+    label: asset.name ?? asset.id
   }))
 
   const openAssetSelectModal = (assetRowIndex: number) => {
@@ -173,7 +174,7 @@ const AssetAmountsInput = ({ address, assetAmounts, onAssetAmountsChange, classN
                 <SelectInput type="button" className={className} disabled={disabled} id={id}>
                   <AssetLogo asset={asset} size={20} />
                   <AssetName>
-                    {asset.name} ({asset.symbol})
+                    {asset.name && asset.symbol ? `${asset.name} (${asset.symbol})` : <HashEllipsed hash={asset.id} />}
                   </AssetName>
                 </SelectInput>
               </AssetSelect>
@@ -188,7 +189,7 @@ const AssetAmountsInput = ({ address, assetAmounts, onAssetAmountsChange, classN
                   min={asset.id === ALPH.id ? minAmountInAlph : 0}
                   max={availableHumanReadableAmount}
                   aria-label={t('Amount')}
-                  label={`${t('Amount')} (${asset.symbol})`}
+                  label={`${t('Amount')} ${asset.symbol ? `(${asset.symbol})` : ''}`}
                   error={errors[index]}
                 />
 
@@ -200,6 +201,7 @@ const AssetAmountsInput = ({ address, assetAmounts, onAssetAmountsChange, classN
                       color={theme.font.secondary}
                       suffix={asset.symbol}
                       decimals={asset.decimals}
+                      isUnknownToken={!asset.symbol}
                     />
                     <span> {t('Available').toLowerCase()}</span>
                   </AvailableAmount>
@@ -235,7 +237,11 @@ const AssetAmountsInput = ({ address, assetAmounts, onAssetAmountsChange, classN
                     ContentLeft={
                       <AssetName>
                         <AssetLogo asset={asset} size={20} />
-                        {asset.name} ({asset.symbol})
+                        {asset.name && asset.symbol ? (
+                          `${asset.name} (${asset.symbol})`
+                        ) : (
+                          <HashEllipsed hash={asset.id} />
+                        )}
                       </AssetName>
                     }
                     ContentRight={
@@ -244,6 +250,7 @@ const AssetAmountsInput = ({ address, assetAmounts, onAssetAmountsChange, classN
                         fadeDecimals
                         suffix={asset.symbol}
                         decimals={asset.decimals}
+                        isUnknownToken={!asset.symbol}
                       />
                     }
                   />
@@ -287,6 +294,7 @@ const AssetName = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
+  max-width: 200px;
 `
 
 const AssetAmountInput = styled(Input)`

--- a/src/modals/SendModals/CheckAddressesBox.tsx
+++ b/src/modals/SendModals/CheckAddressesBox.tsx
@@ -21,8 +21,8 @@ import styled from 'styled-components'
 
 import ActionLink from '@/components/ActionLink'
 import AddressBadge from '@/components/AddressBadge'
-import AddressEllipsed from '@/components/AddressEllipsed'
 import Box from '@/components/Box'
+import HashEllipsed from '@/components/HashEllipsed'
 import HorizontalDivider from '@/components/PageComponents/HorizontalDivider'
 import { useAppSelector } from '@/hooks/redux'
 import { selectContactByAddress } from '@/storage/addresses/addressesSelectors'
@@ -48,7 +48,7 @@ const CheckAddressesBox = ({ fromAddress, toAddressHash, className }: CheckAddre
         <AddressLabel>{t('From')}</AddressLabel>
         <AddressLabelHash>
           <AddressBadge addressHash={fromAddress.hash} truncate showHashWhenNoLabel />
-          {fromAddress.label && <AddressEllipsedStyled addressHash={fromAddress.hash} />}
+          {fromAddress.label && <HashEllipsedStyled hash={fromAddress.hash} />}
         </AddressLabelHash>
       </AddressRow>
       {toAddressHash && (
@@ -61,11 +61,11 @@ const CheckAddressesBox = ({ fromAddress, toAddressHash, className }: CheckAddre
                 <AddressLabelHash>
                   {contact.name}
 
-                  <AddressEllipsedStyled addressHash={contact.address} />
+                  <HashEllipsedStyled hash={contact.address} />
                 </AddressLabelHash>
               ) : (
                 <ActionLinkStyled onClick={() => openInWebBrowser(`${explorerUrl}/addresses/${toAddressHash}`)}>
-                  <AddressEllipsed addressHash={toAddressHash} />
+                  <HashEllipsed hash={toAddressHash} />
                 </ActionLinkStyled>
               )}
             </AddressLabelHash>
@@ -94,7 +94,7 @@ const AddressLabelHash = styled.div`
   gap: 10px;
 `
 
-const AddressEllipsedStyled = styled(AddressEllipsed)`
+const HashEllipsedStyled = styled(HashEllipsed)`
   max-width: 90px;
   color: ${({ theme }) => theme.font.tertiary};
 `

--- a/src/modals/SendModals/CheckAmountsBox.tsx
+++ b/src/modals/SendModals/CheckAmountsBox.tsx
@@ -53,6 +53,7 @@ const CheckAmountsBox = ({ assetAmounts, className }: CheckAmountsBoxProps) => {
                 value={BigInt(asset.amount)}
                 suffix={assetInfo?.symbol}
                 decimals={assetInfo?.decimals}
+                isUnknownToken={!assetInfo?.symbol}
               />
             </AssetAmountRow>
           </Fragment>

--- a/src/pages/UnlockedWallet/AddressesPage/ContactsTabContent.tsx
+++ b/src/pages/UnlockedWallet/AddressesPage/ContactsTabContent.tsx
@@ -23,9 +23,9 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { fadeIn } from '@/animations'
-import AddressEllipsed from '@/components/AddressEllipsed'
 import Button from '@/components/Button'
 import Card from '@/components/Card'
+import HashEllipsed from '@/components/HashEllipsed'
 import Truncate from '@/components/Truncate'
 import { useAppSelector } from '@/hooks/redux'
 import ContactFormModal from '@/modals/ContactFormModal'
@@ -83,7 +83,7 @@ const ContactsTabContent = () => {
           <Card key={contact.address}>
             <ContentRow>
               <Name>{contact.name}</Name>
-              <AddressEllipsedStyled addressHash={contact.address} />
+              <HashEllipsedStyled hash={contact.address} />
             </ContentRow>
             <ButtonsRow>
               <SendButton transparent borderless onClick={() => openSendModal(contact)}>
@@ -126,7 +126,7 @@ const ButtonsRow = styled.div`
   display: flex;
 `
 
-const AddressEllipsedStyled = styled(AddressEllipsed)`
+const HashEllipsedStyled = styled(HashEllipsed)`
   font-size: 16px;
   font-weight: var(--fontWeight-medium);
 `

--- a/src/pages/UnlockedWallet/OverviewPage/AssetsList.tsx
+++ b/src/pages/UnlockedWallet/OverviewPage/AssetsList.tsx
@@ -24,6 +24,7 @@ import styled, { useTheme } from 'styled-components'
 import { fadeIn } from '@/animations'
 import Amount from '@/components/Amount'
 import AssetLogo from '@/components/AssetLogo'
+import HashEllipsed from '@/components/HashEllipsed'
 import { TabItem } from '@/components/TabBar'
 import Table, { TableRow } from '@/components/Table'
 import TableCellAmount from '@/components/TableCellAmount'
@@ -84,13 +85,21 @@ const TokensList = ({ className, limit, addressHashes }: AssetsListProps) => {
           <TokenRow>
             <AssetLogoStyled asset={asset} size={30} />
             <NameColumn>
-              <TokenName>{asset.name}</TokenName>
-              <TokenSymbol>{asset.symbol}</TokenSymbol>
+              <TokenName>{asset.name ?? t('Unknown token')}</TokenName>
+              <TokenSymbol>
+                {asset.symbol ?? <HashEllipsed hash={asset.id} tooltipText={t('Copy token hash')} />}
+              </TokenSymbol>
             </NameColumn>
             <TableCellAmount>
-              <TokenAmount fadeDecimals value={asset.balance} suffix={asset.symbol} decimals={asset.decimals} />
+              <TokenAmount
+                fadeDecimals
+                value={asset.balance}
+                suffix={asset.symbol}
+                decimals={asset.decimals}
+                isUnknownToken={!asset.symbol}
+              />
               {asset.lockedBalance > 0 && (
-                <TokenAvailableAmount>
+                <AmountSubtitle>
                   {`${t('Available')}: `}
                   <Amount
                     fadeDecimals
@@ -98,9 +107,11 @@ const TokensList = ({ className, limit, addressHashes }: AssetsListProps) => {
                     suffix={asset.symbol}
                     color={theme.font.tertiary}
                     decimals={asset.decimals}
+                    isUnknownToken={!asset.symbol}
                   />
-                </TokenAvailableAmount>
+                </AmountSubtitle>
               )}
+              {!asset.symbol && <AmountSubtitle>{t('Raw amount')}</AmountSubtitle>}
             </TableCellAmount>
           </TokenRow>
         </TableRow>
@@ -144,6 +155,7 @@ const TokenName = styled(Truncate)`
 const TokenSymbol = styled.div`
   color: ${({ theme }) => theme.font.tertiary};
   font-size: 11px;
+  width: 200px;
 `
 
 const Column = styled.div`
@@ -156,7 +168,7 @@ const TokenAmount = styled(Amount)`
   color: ${({ theme }) => theme.font.secondary};
 `
 
-const TokenAvailableAmount = styled.div`
+const AmountSubtitle = styled.div`
   color: ${({ theme }) => theme.font.tertiary};
   font-size: 10px;
 `

--- a/src/storage/addresses/addressesSelectors.ts
+++ b/src/storage/addresses/addressesSelectors.ts
@@ -103,8 +103,8 @@ export const selectAddressesAssets = createSelector(
         id: token.id,
         balance: BigInt(token.balance.toString()),
         lockedBalance: BigInt(token.lockedBalance.toString()),
-        name: assetInfo?.name ?? token.id,
-        symbol: assetInfo?.symbol ?? token.id.substring(0, 4).toUpperCase(),
+        name: assetInfo?.name,
+        symbol: assetInfo?.symbol,
         description: assetInfo?.description,
         logoURI: assetInfo?.logoURI,
         decimals: assetInfo?.decimals ?? 0

--- a/src/types/assets.ts
+++ b/src/types/assets.ts
@@ -33,3 +33,6 @@ export type TokenDisplayBalances = Omit<TokenBalances, 'balance' | 'lockedBalanc
 export type Asset = TokenDisplayBalances & PartialBy<TokenInfo, 'symbol' | 'name'>
 
 export type AssetAmount = { id: Asset['id']; amount?: bigint }
+
+export type TransactionInfoAsset = PartialBy<Omit<Asset, 'balance' | 'lockedBalance'>, 'decimals'> &
+  Required<AssetAmount>

--- a/src/types/assets.ts
+++ b/src/types/assets.ts
@@ -19,6 +19,8 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { AddressBalance, Token } from '@alephium/sdk/api/explorer'
 import { TokenInfo } from '@alephium/token-list'
 
+import { PartialBy } from '@/types/generics'
+
 // Used in Redux, amounts need to be in string format
 export type TokenBalances = AddressBalance & { id: Token['id'] }
 
@@ -28,6 +30,6 @@ export type TokenDisplayBalances = Omit<TokenBalances, 'balance' | 'lockedBalanc
   lockedBalance: bigint
 }
 
-export type Asset = TokenDisplayBalances & TokenInfo
+export type Asset = TokenDisplayBalances & PartialBy<TokenInfo, 'symbol' | 'name'>
 
 export type AssetAmount = { id: Asset['id']; amount?: bigint }


### PR DESCRIPTION
Closes #556

### Asset list

- Instead of a logo, display a `?`
- Instead of name, display `Unknown token`
- Instead of symbol, display copy-able token hash
- Instead of symbol next to amount, display nothing, and show the text `Raw amount` below it

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/1579899/225072932-e15c7bd0-6107-4f18-8338-6192439a8979.png">

### Transaction list
- Instead of logo and symbol, simply display the number of unknown tokens (should we add a tooltip that says `5 unknown tokens`?)
 
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/1579899/225073128-8fd42c0f-bd10-4972-b4e6-67e94c302581.png">

### Transaction details modal

- do not display amounts of unknown tokens in the header and instead list then in a separate section in the bottom
- instead of token symbol next to amount, show copy-able token hash

<img width="974" alt="image" src="https://user-images.githubusercontent.com/1579899/225073797-6740501b-bb04-486b-8c72-feb5bf67fa51.png">

### Address cards

- Instead of symbol, follow similar approach with transaction list

<img width="1286" alt="image" src="https://user-images.githubusercontent.com/1579899/225074132-16f78291-683f-47c7-93b9-cf82aa1865a7.png">

### Asset select

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/1579899/225077130-5a456393-3510-48f6-8b0b-30449f2aa5bf.png">
