### PR TITLE
Fix switch to passphrase wallet when single wallet

### DIFF
--- a/src/components/Inputs/Select.tsx
+++ b/src/components/Inputs/Select.tsx
@@ -77,6 +77,7 @@ interface SelectProps<T extends OptionValue> {
   heightSize?: InputHeight
   renderCustomComponent?: (value?: SelectOption<T>, disablePointer?: boolean) => ReactNode
   ListBottomComponent?: ReactNode
+  allowReselectionOnClickWhenSingleOption?: boolean
 }
 
 function Select<T extends OptionValue>({
@@ -96,7 +97,8 @@ function Select<T extends OptionValue>({
   className,
   heightSize,
   renderCustomComponent,
-  ListBottomComponent
+  ListBottomComponent,
+  allowReselectionOnClickWhenSingleOption
 }: SelectProps<T>) {
   const selectedValueRef = useRef<HTMLDivElement>(null)
 
@@ -132,7 +134,11 @@ function Select<T extends OptionValue>({
   )
 
   const handleClick = () => {
-    if (!multipleAvailableOptions) return
+    if (!multipleAvailableOptions) {
+      allowReselectionOnClickWhenSingleOption && options.length === 1 && onSelect(options[0].value)
+
+      return
+    }
 
     setHookCoordinates(getContainerCenter())
     setShowPopup(true)

--- a/src/components/Inputs/WalletPassphrase.tsx
+++ b/src/components/Inputs/WalletPassphrase.tsx
@@ -136,4 +136,6 @@ const ConsentCheckbox = styled.div`
   align-items: center;
   gap: 5px;
   margin-bottom: 16px;
+  text-align: left;
+  justify-content: flex-start;
 `

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -162,7 +162,7 @@ const TableHeaderRow = styled(TableRow)`
   display: flex;
   justify-content: space-between;
   height: 55px;
-  background-color: ${({ theme }) => theme.bg.secondary};
+  background-color: ${({ theme }) => theme.bg.tertiary};
   border-bottom: 1px solid ${({ theme }) => theme.border.secondary};
   padding-right: var(--spacing-2);
 `

--- a/src/components/TableTabBar.tsx
+++ b/src/components/TableTabBar.tsx
@@ -28,7 +28,7 @@ export default styled(TableTabBar)`
 
 const TableTab = styled(Tab)`
   min-width: 60px;
-  background-color: ${({ isActive, theme }) => (isActive ? theme.bg.primary : theme.bg.secondary)};
+  background-color: ${({ isActive, theme }) => (isActive ? theme.bg.primary : theme.bg.tertiary)};
   border: none;
 
   border-bottom: 1px solid ${({ theme }) => theme.border.secondary};

--- a/src/components/ToggleSection.tsx
+++ b/src/components/ToggleSection.tsx
@@ -98,6 +98,7 @@ const Header = styled.div`
 const TitleColumn = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
 `
 
@@ -107,6 +108,7 @@ const Title = styled.div`
 
 const Subtitle = styled.div`
   color: ${({ theme }) => theme.font.tertiary};
+  text-align: left;
 `
 
 const Content = styled(motion.div)`

--- a/src/components/WalletSwitcher.tsx
+++ b/src/components/WalletSwitcher.tsx
@@ -87,6 +87,7 @@ const WalletSwitcher = ({ onUnlock }: WalletSwitcherProps) => {
           id="wallet"
           raised
           skipEqualityCheck
+          allowReselectionOnClickWhenSingleOption
         />
       )}
       <ModalPortal>


### PR DESCRIPTION
@mvaivre the problem I had solved earlier was the one that when the options array of the select field had only 1 item, every click on the select field would just re-select the same item. In the case of the "main address" badge, for example, when there was only 1 address in the wallet, clicking on the badge would re-select it as the "main" address, causing a new write to the localStorage. Since there is an effect that already selects the only option available when there is only one, I ensured to disable the click action in this case. However, this introduced a bug (which this PR fixes) in the case of switching from a "normal" wallet to a "passphrase" wallet. We want the click effect to take action in that case.