### PR TITLE
Replace throttledFetch with fetch-retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-unused-imports": "^2.0.0",
         "events": "^3.3.0",
+        "fetch-retry": "^5.0.6",
         "framer-motion": "^10.11.6",
         "i18next": "^22.4.9",
         "jsdom": "^21.1.1",
@@ -6258,6 +6259,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fetch-retry": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
+      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==",
+      "dev": true
     },
     "node_modules/fflate": {
       "version": "0.4.8",
@@ -17357,6 +17364,12 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "fetch-retry": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
+      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==",
+      "dev": true
     },
     "fflate": {
       "version": "0.4.8",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-unused-imports": "^2.0.0",
     "events": "^3.3.0",
+    "fetch-retry": "^5.0.6",
     "framer-motion": "^10.11.6",
     "i18next": "^22.4.9",
     "jsdom": "^21.1.1",


### PR DESCRIPTION
## Problem

After a discussion on Slack, we agreed that we need to replace the temporary API throttling and retry solution provided by the web3 package (`throttledFetch`) with a more appropriate solution because it doesn't handle concurrency well and is not adaptive enough. The solution should work without knowing the actual API rate limit we implemented because we might change the limit according to the load of the network. If a solution relies on the actual number of limit, then once we update the limit of the services, we will have to update our apps too. That would be painful.

## Proposal

After researching SWR, RTK Query, and TanStack Query, @mvaivre and I agreed that we should first aim for a simple solution that removes the dependency of the `throttledFetch` without requiring too many changes to our current state management and caching paradigms, but yet meets the above requirements. We discovered[ `fetch-retry`](https://www.npmjs.com/package/fetch-retry) which has more than 4M weekly downloads and is well maintained. Just like [SWR](https://swr.vercel.app/docs/error-handling.en-US#error-retry), we implement an exponential backoff algorithm for retries.

## Benchmarking

### Wallet with 1 address
> `87.6%` of our user-base

| | `throttledFetch(5)` | exponential backoff `fetch-retry` | diff |
| ----- | ----- | ----- | ----- |
| network requests | 12 | 12 | 0% |
| loading time | 2.6s | 0.8s | -70% |

### Wallet with 5 addresses

> 1.6% of our user-base

| | `throttledFetch(5)` | exponential backoff `fetch-retry` | diff |
| ----- | ----- | ----- | ----- |
| network requests | 58 | 68 | +17% |
| loading time | 11s | 6.7s | -39% |