### PR TITLE
Capture errors in PostHog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,9 +82,10 @@ const App = () => {
       dispatch(localStorageDataMigrated())
     } catch (e) {
       console.error(e)
+      posthog.capture('Error - Local storage data migration failed')
       dispatch(localStorageDataMigrationFailed())
     }
-  }, [dispatch])
+  }, [dispatch, posthog])
 
   useEffect(() => {
     posthog.people.set({
@@ -130,6 +131,7 @@ const App = () => {
       // TODO: Check if connection to explorer also works
       dispatch(apiClientInitSucceeded({ networkId, networkName: network.name }))
     } catch (e) {
+      // Discuss: Do we want to capture client init errors?
       dispatch(apiClientInitFailed({ networkName: network.name, networkStatus: network.status }))
     }
   }, [network.settings.nodeHost, network.settings.explorerApiHost, network.name, network.status, dispatch])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ const App = () => {
       dispatch(localStorageDataMigrated())
     } catch (e) {
       console.error(e)
-      posthog.capture('Error - Local storage data migration failed')
+      posthog.capture('Error', { message: 'Local storage data migration failed' })
       dispatch(localStorageDataMigrationFailed())
     }
   }, [dispatch, posthog])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ const App = () => {
   }, [dispatch])
 
   useEffect(() => {
-    posthog?.people.set({
+    posthog.people.set({
       wallets: wallets.length,
       theme: settings.theme,
       devTools: settings.devTools,
@@ -96,7 +96,7 @@ const App = () => {
       passwordRequirement: settings.passwordRequirement,
       fiatCurrency: settings.fiatCurrency
     })
-  }, [posthog?.people, settings, wallets.length])
+  }, [posthog.people, settings, wallets.length])
 
   const setSystemLanguage = useCallback(async () => {
     const _window = window as unknown as AlephiumWindow

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,9 +94,10 @@ const App = () => {
       lockTimeInMs: settings.walletLockTimeInMinutes,
       language: settings.language,
       passwordRequirement: settings.passwordRequirement,
-      fiatCurrency: settings.fiatCurrency
+      fiatCurrency: settings.fiatCurrency,
+      network: network.name
     })
-  }, [posthog.people, settings, wallets.length])
+  }, [network.name, posthog.people, settings, wallets.length])
 
   const setSystemLanguage = useCallback(async () => {
     const _window = window as unknown as AlephiumWindow

--- a/src/components/Buttons/ShortcutButtons.tsx
+++ b/src/components/Buttons/ShortcutButtons.tsx
@@ -73,31 +73,31 @@ const ShortcutButtons = ({
   const lockWallet = () => {
     dispatch(walletLocked())
 
-    posthog?.capture('Locked wallet', { origin: analyticsOrigin })
+    posthog.capture('Locked wallet', { origin: analyticsOrigin })
   }
 
   const handleReceiveClick = () => {
     setIsReceiveModalOpen(true)
 
-    posthog?.capture('Receive button clicked', { origin: analyticsOrigin })
+    posthog.capture('Receive button clicked', { origin: analyticsOrigin })
   }
 
   const handleSendClick = () => {
     setIsSendModalOpen(true)
 
-    posthog?.capture('Send button clicked', { origin: analyticsOrigin })
+    posthog.capture('Send button clicked', { origin: analyticsOrigin })
   }
 
   const handleWalletSettingsClick = () => {
     setIsSettingsModalOpen(true)
 
-    posthog?.capture('Wallet settings button clicked', { origin: analyticsOrigin })
+    posthog.capture('Wallet settings button clicked', { origin: analyticsOrigin })
   }
 
   const handleAddressSettingsClick = () => {
     setIsAddressOptionsModalOpen(true)
 
-    posthog?.capture('Address settings button clicked', { origin: analyticsOrigin })
+    posthog.capture('Address settings button clicked', { origin: analyticsOrigin })
   }
 
   return (

--- a/src/components/NetworkSwitch.tsx
+++ b/src/components/NetworkSwitch.tsx
@@ -18,7 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { upperFirst } from 'lodash'
 import { ArrowRight } from 'lucide-react'
-import posthog from 'posthog-js'
+import { usePostHog } from 'posthog-js/react'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { useTheme } from 'styled-components'
@@ -44,6 +44,7 @@ const NetworkSwitch = () => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const network = useAppSelector((state) => state.network)
+  const posthog = usePostHog()
 
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
 
@@ -74,12 +75,12 @@ const NetworkSwitch = () => {
         if (networkId !== undefined) {
           dispatch(networkPresetSwitched(networkName))
 
-          posthog?.capture('Changed network from app header', { network_name: networkName })
+          posthog.capture('Changed network from app header', { network_name: networkName })
           return
         }
       }
     },
-    [dispatch, network.name]
+    [dispatch, network.name, posthog]
   )
 
   return (

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -61,7 +61,6 @@ const PasswordConfirmation: FC<PasswordConfirmationProps> = ({
         onCorrectPasswordEntered(password)
       }
     } catch (e) {
-      // Discuss: Do we want to capture password validation errors?
       dispatch(passwordValidationFailed())
     }
   }

--- a/src/components/PasswordConfirmation.tsx
+++ b/src/components/PasswordConfirmation.tsx
@@ -61,6 +61,7 @@ const PasswordConfirmation: FC<PasswordConfirmationProps> = ({
         onCorrectPasswordEntered(password)
       }
     } catch (e) {
+      // Discuss: Do we want to capture password validation errors?
       dispatch(passwordValidationFailed())
     }
   }

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -44,7 +44,7 @@ const ThemeSwitcher = ({ className }: ThemeSwitcherProps) => {
   const handleThemeToggle = () => {
     toggleTheme(isDark ? 'light' : 'dark')
 
-    posthog?.capture('Toggled theme', { theme })
+    posthog.capture('Toggled theme', { theme })
   }
 
   return (

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -90,7 +90,6 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
       wallet = WalletStorage.load(walletId, password)
     } catch (e) {
       console.error(e)
-      // Discuss: Do we want to capture password validation errors?
       dispatch(passwordValidationFailed())
       return
     }

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -90,6 +90,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
       wallet = WalletStorage.load(walletId, password)
     } catch (e) {
       console.error(e)
+      // Discuss: Do we want to capture password validation errors?
       dispatch(passwordValidationFailed())
       return
     }
@@ -115,6 +116,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
         migrateUserData()
       } catch (e) {
         console.error(e)
+        posthog.capture('Error - User data migration failed')
         dispatch(userDataMigrationFailed())
       }
 

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -123,7 +123,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
 
       WalletStorage.update(walletId, { lastUsed: Date.now() })
 
-      posthog?.capture(event === 'unlock' ? 'Wallet unlocked' : 'Wallet switched', {
+      posthog.capture(event === 'unlock' ? 'Wallet unlocked' : 'Wallet switched', {
         wallet_name_length: wallet.name.length,
         number_of_addresses: (AddressMetadataStorage.load() as []).length,
         number_of_contacts: (ContactsStorage.load() as []).length

--- a/src/contexts/global.tsx
+++ b/src/contexts/global.tsx
@@ -116,7 +116,7 @@ export const GlobalContextProvider: FC<{ overrideContextValue?: PartialDeep<Glob
         migrateUserData()
       } catch (e) {
         console.error(e)
-        posthog.capture('Error - User data migration failed')
+        posthog.capture('Error', { message: 'User data migration failed ' })
         dispatch(userDataMigrationFailed())
       }
 

--- a/src/contexts/walletconnect.tsx
+++ b/src/contexts/walletconnect.tsx
@@ -126,7 +126,7 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
 
       setWalletConnectClient(client)
     } catch (e) {
-      posthog.capture('Error - Could not initialize WalletConnect client')
+      posthog.capture('Error', { message: 'Could not initialize WalletConnect client' })
       console.error('Could not initialize WalletConnect client', e)
     }
   }, [posthog])
@@ -295,7 +295,7 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
         }
       } catch (e) {
         console.error('Error while parsing WalletConnect session request', e)
-        posthog.capture('Error - Could not parse WalletConnect session request')
+        posthog.capture('Error', { message: 'Could not parse WalletConnect session request' })
         onSessionRequestError(event, {
           message: getHumanReadableError(e, 'Error while parsing WalletConnect session request'),
           code: WALLETCONNECT_ERRORS.PARSING_SESSION_REQUEST_FAILED
@@ -317,9 +317,9 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
 
         if (!errorMessage.includes('Pairing already exists')) {
           dispatch(walletConnectPairingFailed(errorMessage))
-          posthog.capture('Error - Could not pair with WalletConnect')
+          posthog.capture('Error', { message: 'Could not pair with WalletConnect' })
         } else {
-          posthog.capture('Error - Could not pair with WalletConnect: Pairing already exists')
+          posthog.capture('Error', { message: 'Could not pair with WalletConnect: Pairing already exists' })
         }
       }
     },

--- a/src/contexts/walletconnect.tsx
+++ b/src/contexts/walletconnect.tsx
@@ -30,6 +30,7 @@ import SignClient from '@walletconnect/sign-client'
 import { EngineTypes, SignClientTypes } from '@walletconnect/types'
 import { getSdkError } from '@walletconnect/utils'
 import { partition } from 'lodash'
+import { usePostHog } from 'posthog-js/react'
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -96,6 +97,7 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
   const { t } = useTranslation()
   const addresses = useAppSelector(selectAllAddresses)
   const dispatch = useAppDispatch()
+  const posthog = usePostHog()
 
   const [isDeployContractSendModalOpen, setIsDeployContractSendModalOpen] = useState(false)
   const [isCallScriptSendModalOpen, setIsCallScriptSendModalOpen] = useState(false)
@@ -124,9 +126,10 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
 
       setWalletConnectClient(client)
     } catch (e) {
+      posthog.capture('Error - Could not initialize WalletConnect client')
       console.error('Could not initialize WalletConnect client', e)
     }
-  }, [])
+  }, [posthog])
 
   useEffect(() => {
     if (!walletConnectClient) initializeWalletConnectClient()
@@ -292,13 +295,14 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
         }
       } catch (e) {
         console.error('Error while parsing WalletConnect session request', e)
+        posthog.capture('Error - Could not parse WalletConnect session request')
         onSessionRequestError(event, {
           message: getHumanReadableError(e, 'Error while parsing WalletConnect session request'),
           code: WALLETCONNECT_ERRORS.PARSING_SESSION_REQUEST_FAILED
         })
       }
     },
-    [addresses, onSessionRequestError, walletConnectClient]
+    [addresses, onSessionRequestError, posthog, walletConnectClient]
   )
 
   const connectToWalletConnect = useCallback(
@@ -313,10 +317,13 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
 
         if (!errorMessage.includes('Pairing already exists')) {
           dispatch(walletConnectPairingFailed(errorMessage))
+          posthog.capture('Error - Could not pair with WalletConnect')
+        } else {
+          posthog.capture('Error - Could not pair with WalletConnect: Pairing already exists')
         }
       }
     },
-    [dispatch, t, walletConnectClient]
+    [dispatch, posthog, t, walletConnectClient]
   )
 
   const onSessionDelete = useCallback(() => {

--- a/src/contexts/walletconnect.tsx
+++ b/src/contexts/walletconnect.tsx
@@ -317,13 +317,10 @@ export const WalletConnectContextProvider: FC = ({ children }) => {
 
         if (!errorMessage.includes('Pairing already exists')) {
           dispatch(walletConnectPairingFailed(errorMessage))
-          posthog.capture('Error', { message: 'Could not pair with WalletConnect' })
-        } else {
-          posthog.capture('Error', { message: 'Could not pair with WalletConnect: Pairing already exists' })
         }
       }
     },
-    [dispatch, posthog, t, walletConnectClient]
+    [dispatch, t, walletConnectClient]
   )
 
   const onSessionDelete = useCallback(() => {

--- a/src/hooks/useGasSettings.tsx
+++ b/src/hooks/useGasSettings.tsx
@@ -62,7 +62,7 @@ const useGasSettings = (initialGasAmount?: string, initialGasPrice?: string) => 
       )
     } catch (e) {
       console.error(e)
-      posthog.capture('Error - Setting gas price')
+      posthog.capture('Error', { message: 'Setting gas price' })
       return
     }
   }

--- a/src/hooks/useGasSettings.tsx
+++ b/src/hooks/useGasSettings.tsx
@@ -17,11 +17,14 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { formatAmountForDisplay, fromHumanReadableAmount, MINIMAL_GAS_AMOUNT, MINIMAL_GAS_PRICE } from '@alephium/sdk'
+import { usePostHog } from 'posthog-js/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const useGasSettings = (initialGasAmount?: string, initialGasPrice?: string) => {
   const { t } = useTranslation()
+  const posthog = usePostHog()
+
   const [gasAmount, setGasAmount] = useState(initialGasAmount)
   const [gasPrice, setGasPrice] = useState(initialGasPrice)
   const [gasAmountError, setGasAmountError] = useState('')
@@ -59,6 +62,7 @@ const useGasSettings = (initialGasAmount?: string, initialGasPrice?: string) => 
       )
     } catch (e) {
       console.error(e)
+      posthog.capture('Error - Setting gas price')
       return
     }
   }

--- a/src/hooks/useLatestGitHubRelease.ts
+++ b/src/hooks/useLatestGitHubRelease.ts
@@ -70,7 +70,7 @@ const useLatestGitHubRelease = () => {
       try {
         await checkForManualDownload()
       } catch (e) {
-        posthog.capture('Error - Checking for latest release version for manual download')
+        posthog.capture('Error', { message: 'Checking for latest release version for manual download' })
         console.error(e)
       }
     } else if (isVersionNewer(version)) {

--- a/src/hooks/useLatestGitHubRelease.ts
+++ b/src/hooks/useLatestGitHubRelease.ts
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { compareVersions } from 'compare-versions'
+import { usePostHog } from 'posthog-js/react'
 import { useState } from 'react'
 
 import { AlephiumWindow } from '@/types/window'
@@ -33,6 +34,8 @@ const semverRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)?$/
 const ONE_HOUR = 1000 * 60 * 60
 
 const useLatestGitHubRelease = () => {
+  const posthog = usePostHog()
+
   const [newVersion, setNewVersion] = useState('')
   const [timeUntilNextFetch, setTimeUntilNextFetch] = useState(0)
   const [requiresManualDownload, setRequiresManualDownload] = useState(false)
@@ -67,6 +70,7 @@ const useLatestGitHubRelease = () => {
       try {
         await checkForManualDownload()
       } catch (e) {
+        posthog.capture('Error - Checking for latest release version for manual download')
         console.error(e)
       }
     } else if (isVersionNewer(version)) {

--- a/src/modals/AddressOptionsModal.tsx
+++ b/src/modals/AddressOptionsModal.tsx
@@ -75,8 +75,8 @@ const AddressOptionsModal = ({ addressHash, onClose }: AddressOptionsModalProps)
 
     onClose()
 
-    posthog?.capture('Changed address settings', { label_length: settings.label.length })
-    isDefaultAddressToggleEnabled && posthog?.capture('Changed default address')
+    posthog.capture('Changed address settings', { label_length: settings.label.length })
+    isDefaultAddressToggleEnabled && posthog.capture('Changed default address')
   }
 
   let defaultAddressMessage = `${t('Default address for sending transactions.')} `

--- a/src/modals/AddressSweepModal.tsx
+++ b/src/modals/AddressSweepModal.tsx
@@ -79,7 +79,7 @@ const AddressSweepModal = ({ sweepAddress, onClose, onSuccessfulSweep }: Address
         setFee(fees)
       } catch (e) {
         dispatch(transactionBuildFailed(getHumanReadableError(e, t('Error while building transaction'))))
-        posthog.capture('Error - Building transaction')
+        posthog.capture('Error', { message: 'Building transaction' })
       }
       setIsLoading(false)
     }
@@ -116,7 +116,7 @@ const AddressSweepModal = ({ sweepAddress, onClose, onSuccessfulSweep }: Address
           getHumanReadableError(e, t('Error while sweeping address {{ from }}', { from: sweepAddresses.from }))
         )
       )
-      posthog.capture('Error - Sweeping address')
+      posthog.capture('Error', { message: 'Sweeping address' })
     }
     setIsLoading(false)
   }

--- a/src/modals/AddressSweepModal.tsx
+++ b/src/modals/AddressSweepModal.tsx
@@ -108,7 +108,7 @@ const AddressSweepModal = ({ sweepAddress, onClose, onSuccessfulSweep }: Address
       onClose()
       onSuccessfulSweep && onSuccessfulSweep()
 
-      posthog?.capture('Swept address assets')
+      posthog.capture('Swept address assets')
     } catch (e) {
       dispatch(
         transactionSendFailed(

--- a/src/modals/AddressSweepModal.tsx
+++ b/src/modals/AddressSweepModal.tsx
@@ -79,12 +79,13 @@ const AddressSweepModal = ({ sweepAddress, onClose, onSuccessfulSweep }: Address
         setFee(fees)
       } catch (e) {
         dispatch(transactionBuildFailed(getHumanReadableError(e, t('Error while building transaction'))))
+        posthog.capture('Error - Building transaction')
       }
       setIsLoading(false)
     }
 
     buildTransactions()
-  }, [dispatch, sweepAddresses.from, sweepAddresses.to, t])
+  }, [dispatch, posthog, sweepAddresses.from, sweepAddresses.to, t])
 
   const onSweepClick = async () => {
     if (!sweepAddresses.from || !sweepAddresses.to) return
@@ -115,6 +116,7 @@ const AddressSweepModal = ({ sweepAddress, onClose, onSuccessfulSweep }: Address
           getHumanReadableError(e, t('Error while sweeping address {{ from }}', { from: sweepAddresses.from }))
         )
       )
+      posthog.capture('Error - Sweeping address')
     }
     setIsLoading(false)
   }

--- a/src/modals/CSVExportModal.tsx
+++ b/src/modals/CSVExportModal.tsx
@@ -53,7 +53,7 @@ const CSVExportModal = ({ addressHash, ...props }: CSVExportModalProps) => {
     props.onClose()
     getCSVFile()
 
-    posthog?.capture('Exported CSV', { time_period: selectedTimePeriod })
+    posthog.capture('Exported CSV', { time_period: selectedTimePeriod })
   }
 
   const getCSVFile = async () => {

--- a/src/modals/ContactFormModal.tsx
+++ b/src/modals/ContactFormModal.tsx
@@ -75,7 +75,7 @@ const ContactFormModal = ({ contact, onClose }: ContactFormModalProps) => {
       })
     } catch (e) {
       dispatch(contactStorageFailed(getHumanReadableError(e, t('Could not save contact.'))))
-      posthog.capture('Error - Could not save contact')
+      posthog.capture('Error', { message: 'Could not save contact' })
     }
   }
 
@@ -88,7 +88,7 @@ const ContactFormModal = ({ contact, onClose }: ContactFormModalProps) => {
       posthog.capture('Deleted contact')
     } catch (e) {
       dispatch(contactDeletionFailed(getHumanReadableError(e, t('Could not delete contact.'))))
-      posthog.capture('Error - Could not delete contact')
+      posthog.capture('Error', { message: 'Could not delete contact' })
     } finally {
       onClose()
     }

--- a/src/modals/ContactFormModal.tsx
+++ b/src/modals/ContactFormModal.tsx
@@ -75,6 +75,7 @@ const ContactFormModal = ({ contact, onClose }: ContactFormModalProps) => {
       })
     } catch (e) {
       dispatch(contactStorageFailed(getHumanReadableError(e, t('Could not save contact.'))))
+      posthog.capture('Error - Could not save contact')
     }
   }
 
@@ -87,6 +88,7 @@ const ContactFormModal = ({ contact, onClose }: ContactFormModalProps) => {
       posthog.capture('Deleted contact')
     } catch (e) {
       dispatch(contactDeletionFailed(getHumanReadableError(e, t('Could not delete contact.'))))
+      posthog.capture('Error - Could not delete contact')
     } finally {
       onClose()
     }

--- a/src/modals/ContactFormModal.tsx
+++ b/src/modals/ContactFormModal.tsx
@@ -70,7 +70,7 @@ const ContactFormModal = ({ contact, onClose }: ContactFormModalProps) => {
       dispatch(contactStoredInPersistentStorage({ ...contactData, id }))
       onClose()
 
-      posthog?.capture(contactData.id ? 'Edited contact' : 'Saved new contact', {
+      posthog.capture(contactData.id ? 'Edited contact' : 'Saved new contact', {
         contact_name_length: contactData.name.length
       })
     } catch (e) {
@@ -84,7 +84,7 @@ const ContactFormModal = ({ contact, onClose }: ContactFormModalProps) => {
     try {
       ContactsStorage.deleteContact(contact)
       dispatch(contactDeletedFromPeristentStorage(contact.id))
-      posthog?.capture('Deleted contact')
+      posthog.capture('Deleted contact')
     } catch (e) {
       dispatch(contactDeletionFailed(getHumanReadableError(e, t('Could not delete contact.'))))
     } finally {

--- a/src/modals/NewAddressModal.tsx
+++ b/src/modals/NewAddressModal.tsx
@@ -76,11 +76,11 @@ const NewAddressModal = ({ title, onClose, singleAddress }: NewAddressModalProps
 
       saveNewAddresses([{ ...newAddressData, ...settings }])
 
-      posthog?.capture('New address created', { label_length: settings.label.length })
+      posthog.capture('New address created', { label_length: settings.label.length })
     } else {
       generateAndSaveOneAddressPerGroup({ labelPrefix: addressLabel.title, labelColor: addressLabel.color })
 
-      posthog?.capture('One address per group generated', { label_length: addressLabel.title.length })
+      posthog.capture('One address per group generated', { label_length: addressLabel.title.length })
     }
     onClose()
   }

--- a/src/modals/NotificationsModal.tsx
+++ b/src/modals/NotificationsModal.tsx
@@ -38,7 +38,7 @@ const NotificationsModal = ({ onClose, focusMode }: ModalContainerProps) => {
   const lockWallet = () => {
     dispatch(walletLocked())
 
-    posthog?.capture('Locked wallet', { origin: 'notifications' })
+    posthog.capture('Locked wallet', { origin: 'notifications' })
   }
 
   return (

--- a/src/modals/SendModals/CallContract/BuildTxModalContent.tsx
+++ b/src/modals/SendModals/CallContract/BuildTxModalContent.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { fromHumanReadableAmount } from '@alephium/sdk'
+import { usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -43,6 +44,7 @@ interface CallContractBuildTxModalContentProps {
 
 const CallContractBuildTxModalContent = ({ data, onSubmit, onCancel }: CallContractBuildTxModalContentProps) => {
   const { t } = useTranslation()
+  const posthog = usePostHog()
   const {
     gasAmount,
     gasAmountError,
@@ -68,8 +70,9 @@ const CallContractBuildTxModalContent = ({ data, onSubmit, onCancel }: CallContr
       setIsAmountValid(!alphAmount || isAmountWithinRange(fromHumanReadableAmount(alphAmount), availableBalance))
     } catch (e) {
       console.error(e)
+      posthog.capture('Error - Could not determine if amount is valid')
     }
-  }, [alphAmount, availableBalance])
+  }, [alphAmount, availableBalance, posthog])
 
   if (fromAddress === undefined) {
     onCancel()

--- a/src/modals/SendModals/CallContract/BuildTxModalContent.tsx
+++ b/src/modals/SendModals/CallContract/BuildTxModalContent.tsx
@@ -70,7 +70,7 @@ const CallContractBuildTxModalContent = ({ data, onSubmit, onCancel }: CallContr
       setIsAmountValid(!alphAmount || isAmountWithinRange(fromHumanReadableAmount(alphAmount), availableBalance))
     } catch (e) {
       console.error(e)
-      posthog.capture('Error - Could not determine if amount is valid')
+      posthog.capture('Error', { message: 'Could not determine if amount is valid' })
     }
   }, [alphAmount, availableBalance, posthog])
 

--- a/src/modals/SendModals/CallContract/index.tsx
+++ b/src/modals/SendModals/CallContract/index.tsx
@@ -79,7 +79,7 @@ const buildTransaction = async (txData: CallContractTxData, ctx: TxContext) => {
   ctx.setFees(BigInt(response.gasAmount) * BigInt(response.gasPrice))
 }
 
-const handleSend = async ({ fromAddress, assetAmounts }: CallContractTxData, ctx: TxContext, posthog?: PostHog) => {
+const handleSend = async ({ fromAddress, assetAmounts }: CallContractTxData, ctx: TxContext, posthog: PostHog) => {
   if (!ctx.unsignedTransaction) throw Error('No unsignedTransaction available')
 
   const { attoAlphAmount, tokens } = getOptionalTransactionAssetAmounts(assetAmounts)
@@ -98,7 +98,7 @@ const handleSend = async ({ fromAddress, assetAmounts }: CallContractTxData, ctx
     })
   )
 
-  posthog?.capture('Called smart contract')
+  posthog.capture('Called smart contract')
 
   return data.signature
 }

--- a/src/modals/SendModals/DeployContract/index.tsx
+++ b/src/modals/SendModals/DeployContract/index.tsx
@@ -93,7 +93,7 @@ const SendModalDeployContract = ({ onClose, initialTxData, txData }: DeployContr
 
 export default SendModalDeployContract
 
-const handleSend = async ({ fromAddress }: DeployContractTxData, context: TxContext, posthog?: PostHog) => {
+const handleSend = async ({ fromAddress }: DeployContractTxData, context: TxContext, posthog: PostHog) => {
   if (!context.unsignedTransaction) throw Error('No unsignedTransaction available')
 
   const data = await signAndSendTransaction(fromAddress, context.unsignedTxId, context.unsignedTransaction.unsignedTx)
@@ -109,7 +109,7 @@ const handleSend = async ({ fromAddress }: DeployContractTxData, context: TxCont
     })
   )
 
-  posthog?.capture('Deployed smart contract')
+  posthog.capture('Deployed smart contract')
 
   return data.signature
 }

--- a/src/modals/SendModals/GasSettings.tsx
+++ b/src/modals/SendModals/GasSettings.tsx
@@ -55,7 +55,7 @@ const GasSettings = ({
       setExpectedFee(BigInt(gasAmount) * fromHumanReadableAmount(gasPrice))
     } catch (e) {
       console.error(e)
-      posthog.capture('Error - Could not set expected fee')
+      posthog.capture('Error', { message: 'Could not set expected fee' })
     }
   }, [gasAmount, gasPrice, posthog])
 

--- a/src/modals/SendModals/GasSettings.tsx
+++ b/src/modals/SendModals/GasSettings.tsx
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { formatAmountForDisplay, fromHumanReadableAmount, MINIMAL_GAS_AMOUNT, MINIMAL_GAS_PRICE } from '@alephium/sdk'
+import { usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -41,6 +42,7 @@ const GasSettings = ({
   onGasPriceChange
 }: GasSettingsProps) => {
   const { t } = useTranslation()
+  const posthog = usePostHog()
 
   const [expectedFee, setExpectedFee] = useState<bigint>()
 
@@ -53,8 +55,9 @@ const GasSettings = ({
       setExpectedFee(BigInt(gasAmount) * fromHumanReadableAmount(gasPrice))
     } catch (e) {
       console.error(e)
+      posthog.capture('Error - Could not set expected fee')
     }
-  }, [gasAmount, gasPrice])
+  }, [gasAmount, gasPrice, posthog])
 
   return (
     <>

--- a/src/modals/SendModals/SendModal.tsx
+++ b/src/modals/SendModals/SendModal.tsx
@@ -57,7 +57,7 @@ type SendModalProps<PT extends { fromAddress: Address }, T extends PT> = {
   BuildTxModalContent: (props: { data: PT; onSubmit: (data: T) => void; onCancel: () => void }) => JSX.Element | null
   CheckTxModalContent: (props: CheckTxProps<T>) => JSX.Element | null
   buildTransaction: (data: T, context: TxContext) => Promise<void>
-  handleSend: (data: T, context: TxContext, posthog?: PostHog) => Promise<string | undefined>
+  handleSend: (data: T, context: TxContext, posthog: PostHog) => Promise<string | undefined>
   getWalletConnectResult: (context: TxContext, signature: string) => node.SignResult
   txData?: T
   initialStep?: Step

--- a/src/modals/SendModals/SendModal.tsx
+++ b/src/modals/SendModals/SendModal.tsx
@@ -151,10 +151,12 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
         if (error?.detail && (error.detail.includes('consolidating') || error.detail.includes('consolidate'))) {
           setIsConsolidateUTXOsModalVisible(true)
           setConsolidationRequired(true)
+          posthog.capture('Error - Could not build tx, consolidation required')
         } else {
           const errorMessage = getHumanReadableError(e, t('Error while building transaction'))
 
           dispatch(transactionBuildFailed(errorMessage))
+          posthog.capture('Error - Could not build tx')
 
           if (isRequestToApproveContractCall) {
             if (requestEvent)
@@ -177,6 +179,7 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
       isRequestToApproveContractCall,
       onClose,
       onSessionRequestError,
+      posthog,
       requestEvent,
       t,
       txContext
@@ -213,6 +216,7 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
       setStep('tx-sent')
     } catch (e) {
       dispatch(transactionSendFailed(getHumanReadableError(e, t('Error while sending the transaction'))))
+      posthog.capture('Error - Could not send tx')
 
       if (requestEvent)
         onSessionRequestError(requestEvent, {

--- a/src/modals/SendModals/SendModal.tsx
+++ b/src/modals/SendModals/SendModal.tsx
@@ -151,12 +151,12 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
         if (error?.detail && (error.detail.includes('consolidating') || error.detail.includes('consolidate'))) {
           setIsConsolidateUTXOsModalVisible(true)
           setConsolidationRequired(true)
-          posthog.capture('Error - Could not build tx, consolidation required')
+          posthog.capture('Error', { message: 'Could not build tx, consolidation required' })
         } else {
           const errorMessage = getHumanReadableError(e, t('Error while building transaction'))
 
           dispatch(transactionBuildFailed(errorMessage))
-          posthog.capture('Error - Could not build tx')
+          posthog.capture('Error', { message: 'Could not build tx' })
 
           if (isRequestToApproveContractCall) {
             if (requestEvent)
@@ -216,7 +216,7 @@ function SendModal<PT extends { fromAddress: Address }, T extends PT>({
       setStep('tx-sent')
     } catch (e) {
       dispatch(transactionSendFailed(getHumanReadableError(e, t('Error while sending the transaction'))))
-      posthog.capture('Error - Could not send tx')
+      posthog.capture('Error', { message: 'Could not send tx' })
 
       if (requestEvent)
         onSessionRequestError(requestEvent, {

--- a/src/modals/SendModals/Transfer/index.tsx
+++ b/src/modals/SendModals/Transfer/index.tsx
@@ -100,7 +100,7 @@ const buildTransaction = async (transactionData: TransferTxData, context: TxCont
   }
 }
 
-const handleSend = async (transactionData: TransferTxData, context: TxContext, posthog?: PostHog) => {
+const handleSend = async (transactionData: TransferTxData, context: TxContext, posthog: PostHog) => {
   const { fromAddress, toAddress, lockTime: lockDateTime, assetAmounts } = transactionData
   const { isSweeping, sweepUnsignedTxs, consolidationRequired, unsignedTxId, unsignedTransaction } = context
 
@@ -130,7 +130,7 @@ const handleSend = async (transactionData: TransferTxData, context: TxContext, p
         )
       }
 
-      posthog?.capture('Swept address assets')
+      posthog.capture('Swept address assets')
     } else if (unsignedTransaction) {
       const data = await signAndSendTransaction(fromAddress, unsignedTxId, unsignedTransaction.unsignedTx)
 
@@ -148,7 +148,7 @@ const handleSend = async (transactionData: TransferTxData, context: TxContext, p
         })
       )
 
-      posthog?.capture('Sent transaction', { number_of_tokens: tokens.length, locked: !!lockTime })
+      posthog.capture('Sent transaction', { number_of_tokens: tokens.length, locked: !!lockTime })
 
       return data.txId
     }

--- a/src/modals/SettingsModal/DevToolsSettingsSection.tsx
+++ b/src/modals/SettingsModal/DevToolsSettingsSection.tsx
@@ -79,7 +79,7 @@ const DevToolsSettingsSection = () => {
       posthog.capture('Copied address private key')
     } catch (e) {
       dispatch(copyToClipboardFailed(getHumanReadableError(e, t('Could not copy private key.'))))
-      posthog.capture('Error - Could not copy private key')
+      posthog.capture('Error', { message: 'Could not copy private key' })
     } finally {
       closePasswordModal()
     }

--- a/src/modals/SettingsModal/DevToolsSettingsSection.tsx
+++ b/src/modals/SettingsModal/DevToolsSettingsSection.tsx
@@ -61,7 +61,7 @@ const DevToolsSettingsSection = () => {
   const toggleDevTools = () => {
     dispatch(devToolsToggled())
 
-    posthog?.capture('Enabled dev tools')
+    posthog.capture('Enabled dev tools')
   }
 
   const confirmAddressPrivateKeyCopyWithPassword = (address: Address) => {
@@ -76,7 +76,7 @@ const DevToolsSettingsSection = () => {
       await navigator.clipboard.writeText(selectedAddress.privateKey)
       dispatch(copiedToClipboard(t('Private key copied!')))
 
-      posthog?.capture('Copied address private key')
+      posthog.capture('Copied address private key')
     } catch (e) {
       dispatch(copyToClipboardFailed(getHumanReadableError(e, t('Could not copy private key.'))))
     } finally {
@@ -91,7 +91,7 @@ const DevToolsSettingsSection = () => {
 
   const handleFaucetCall = () => {
     defaultAddress && dispatch(receiveTestnetTokens(defaultAddress?.hash))
-    posthog?.capture('Requested testnet tokens')
+    posthog.capture('Requested testnet tokens')
   }
 
   return (

--- a/src/modals/SettingsModal/DevToolsSettingsSection.tsx
+++ b/src/modals/SettingsModal/DevToolsSettingsSection.tsx
@@ -79,6 +79,7 @@ const DevToolsSettingsSection = () => {
       posthog.capture('Copied address private key')
     } catch (e) {
       dispatch(copyToClipboardFailed(getHumanReadableError(e, t('Could not copy private key.'))))
+      posthog.capture('Error - Could not copy private key')
     } finally {
       closePasswordModal()
     }

--- a/src/modals/SettingsModal/EditWalletNameModal.tsx
+++ b/src/modals/SettingsModal/EditWalletNameModal.tsx
@@ -60,6 +60,7 @@ const EditWalletNameModal = (props: CenteredModalProps) => {
       posthog.capture('Changed wallet name', { wallet_name_length: data.name.length })
     } catch (e) {
       dispatch(walletNameStorageFailed(getHumanReadableError(e, t('Could not save new wallet name.'))))
+      posthog.capture('Error - Could not save new wallet name')
     }
   }
 

--- a/src/modals/SettingsModal/EditWalletNameModal.tsx
+++ b/src/modals/SettingsModal/EditWalletNameModal.tsx
@@ -60,7 +60,7 @@ const EditWalletNameModal = (props: CenteredModalProps) => {
       posthog.capture('Changed wallet name', { wallet_name_length: data.name.length })
     } catch (e) {
       dispatch(walletNameStorageFailed(getHumanReadableError(e, t('Could not save new wallet name.'))))
-      posthog.capture('Error - Could not save new wallet name')
+      posthog.capture('Error', { message: 'Could not save new wallet name' })
     }
   }
 

--- a/src/modals/SettingsModal/EditWalletNameModal.tsx
+++ b/src/modals/SettingsModal/EditWalletNameModal.tsx
@@ -57,7 +57,7 @@ const EditWalletNameModal = (props: CenteredModalProps) => {
       dispatch(newWalletNameStored(data.name))
       props.onClose()
 
-      posthog?.capture('Changed wallet name', { wallet_name_length: data.name.length })
+      posthog.capture('Changed wallet name', { wallet_name_length: data.name.length })
     } catch (e) {
       dispatch(walletNameStorageFailed(getHumanReadableError(e, t('Could not save new wallet name.'))))
     }

--- a/src/modals/SettingsModal/GeneralSettingsSection.tsx
+++ b/src/modals/SettingsModal/GeneralSettingsSection.tsx
@@ -63,7 +63,7 @@ const GeneralSettingsSection = ({ className }: GeneralSettingsSectionProps) => {
     } else {
       dispatch(passwordRequirementToggled())
 
-      posthog?.capture('Enabled password requirement')
+      posthog.capture('Enabled password requirement')
     }
   }, [dispatch, passwordRequirement, posthog])
 
@@ -71,19 +71,19 @@ const GeneralSettingsSection = ({ className }: GeneralSettingsSectionProps) => {
     dispatch(passwordRequirementToggled())
     setIsPasswordModalOpen(false)
 
-    posthog?.capture('Disabled password requirement')
+    posthog.capture('Disabled password requirement')
   }, [dispatch, posthog])
 
   const handleLanguageChange = (language: Language) => {
     dispatch(languageChanged(language))
 
-    posthog?.capture('Changed language', { language })
+    posthog.capture('Changed language', { language })
   }
 
   const handleFiatCurrencyChange = (currency: Currency) => {
     dispatch(fiatCurrencyChanged(currency))
 
-    posthog?.capture('Changed fiat currency', { currency })
+    posthog.capture('Changed fiat currency', { currency })
   }
 
   const handleDiscreetModeToggle = () => dispatch(discreetModeToggled())
@@ -93,13 +93,13 @@ const GeneralSettingsSection = ({ className }: GeneralSettingsSectionProps) => {
 
     dispatch(walletLockTimeChanged(time))
 
-    posthog?.capture('Changed wallet lock time', { time })
+    posthog.capture('Changed wallet lock time', { time })
   }
 
   const handleThemeSelect = (theme: ThemeSettings) => {
     switchTheme(theme)
 
-    posthog?.capture('Changed theme', { theme })
+    posthog.capture('Changed theme', { theme })
   }
 
   const handleAnalyticsToggle = (toggle: boolean) => {
@@ -107,12 +107,12 @@ const GeneralSettingsSection = ({ className }: GeneralSettingsSectionProps) => {
 
     if (toggle && !import.meta.env.DEV) {
       const id = AnalyticsStorage.load()
-      posthog?.identify(id)
-      posthog?.opt_in_capturing()
-      posthog?.capture('Enabled analytics')
+      posthog.identify(id)
+      posthog.opt_in_capturing()
+      posthog.capture('Enabled analytics')
     } else {
-      posthog?.capture('Disabled analytics')
-      posthog?.opt_out_capturing()
+      posthog.capture('Disabled analytics')
+      posthog.opt_out_capturing()
     }
   }
 

--- a/src/modals/SettingsModal/NetworkSettingsSection.tsx
+++ b/src/modals/SettingsModal/NetworkSettingsSection.tsx
@@ -105,7 +105,7 @@ const NetworkSettingsSection = () => {
           dispatch(networkPresetSwitched(networkName))
           setTempAdvancedSettings(newNetworkSettings)
 
-          posthog?.capture('Changed network', { network_name: networkName })
+          posthog.capture('Changed network', { network_name: networkName })
           return
         }
 
@@ -119,7 +119,7 @@ const NetworkSettingsSection = () => {
           dispatch(customNetworkSettingsSaved(settings))
           setTempAdvancedSettings(settings)
 
-          posthog?.capture('Saved custom network settings')
+          posthog.capture('Saved custom network settings')
         }
       }
     },
@@ -139,7 +139,7 @@ const NetworkSettingsSection = () => {
     overrideSelectionIfMatchesPreset(tempAdvancedSettings)
     dispatch(customNetworkSettingsSaved(tempAdvancedSettings))
 
-    posthog?.capture('Saved custom network settings')
+    posthog.capture('Saved custom network settings')
   }, [dispatch, network.name, overrideSelectionIfMatchesPreset, posthog, selectedNetwork, tempAdvancedSettings])
 
   // Set existing value on mount

--- a/src/modals/SettingsModal/WalletsSettingsSection.tsx
+++ b/src/modals/SettingsModal/WalletsSettingsSection.tsx
@@ -58,13 +58,13 @@ const WalletsSettingsSection = () => {
     dispatch(walletId === activeWallet.id ? activeWalletDeleted() : walletDeleted(walletId))
     setWalletToRemove(undefined)
 
-    posthog?.capture('Deleted wallet')
+    posthog.capture('Deleted wallet')
   }
 
   const lockWallet = () => {
     dispatch(walletLocked())
 
-    posthog?.capture('Locked wallet', { origin: 'settings' })
+    posthog.capture('Locked wallet', { origin: 'settings' })
   }
 
   return (

--- a/src/modals/WalletConnectModal.tsx
+++ b/src/modals/WalletConnectModal.tsx
@@ -151,7 +151,7 @@ const WalletConnectModal = ({ onClose }: WalletConnectModalProps) => {
     await acknowledged()
     onClose()
 
-    posthog?.capture('Approved WalletConnect connection')
+    posthog.capture('Approved WalletConnect connection')
 
     electron?.app.hide()
   }
@@ -164,7 +164,7 @@ const WalletConnectModal = ({ onClose }: WalletConnectModalProps) => {
     onSessionDelete()
     onClose()
 
-    posthog?.capture('Rejected WalletConnect connection by clicking "Reject"')
+    posthog.capture('Rejected WalletConnect connection by clicking "Reject"')
 
     electron?.app.hide()
   }
@@ -176,7 +176,7 @@ const WalletConnectModal = ({ onClose }: WalletConnectModalProps) => {
     onClose()
     onSessionDelete()
 
-    posthog?.capture('Clicked WalletConnect disconnect button')
+    posthog.capture('Clicked WalletConnect disconnect button')
   }
 
   const rejectConnectionAndCloseModal = async () => {
@@ -187,14 +187,14 @@ const WalletConnectModal = ({ onClose }: WalletConnectModalProps) => {
 
     onClose()
 
-    posthog?.capture('Rejected WalletConnect connection by closing modal')
+    posthog.capture('Rejected WalletConnect connection by closing modal')
   }
 
   const generateAddressInGroup = () => {
     const address = generateAddress({ group })
     saveNewAddresses([{ ...address, isDefault: false, color: getRandomLabelColor() }])
 
-    posthog?.capture('New address created through WalletConnect modal')
+    posthog.capture('New address created through WalletConnect modal')
   }
 
   const showManualInitialization = wcSessionState === 'uninitialized' && addresses.length > 0

--- a/src/pages/NewWallet/CheckWordsPage.tsx
+++ b/src/pages/NewWallet/CheckWordsPage.tsx
@@ -187,7 +187,7 @@ const CheckWordsPage = () => {
     if (areWordsValid && plainWallet) {
       saveNewWallet({ wallet: plainWallet, walletName, password })
 
-      posthog?.capture('New wallet created', { wallet_name_length: walletName.length })
+      posthog.capture('New wallet created', { wallet_name_length: walletName.length })
 
       return true
     }

--- a/src/pages/NewWallet/ImportWordsPage.tsx
+++ b/src/pages/NewWallet/ImportWordsPage.tsx
@@ -86,6 +86,7 @@ const ImportWordsPage = () => {
       onButtonNext()
     } catch (e) {
       dispatch(walletCreationFailed(getHumanReadableError(e, t('Error while importing wallet'))))
+      posthog.capture('Error - Could not import wallet')
     }
   }
 

--- a/src/pages/NewWallet/ImportWordsPage.tsx
+++ b/src/pages/NewWallet/ImportWordsPage.tsx
@@ -86,7 +86,7 @@ const ImportWordsPage = () => {
       onButtonNext()
     } catch (e) {
       dispatch(walletCreationFailed(getHumanReadableError(e, t('Error while importing wallet'))))
-      posthog.capture('Error - Could not import wallet')
+      posthog.capture('Error', { message: 'Could not import wallet' })
     }
   }
 

--- a/src/pages/NewWallet/ImportWordsPage.tsx
+++ b/src/pages/NewWallet/ImportWordsPage.tsx
@@ -80,7 +80,7 @@ const ImportWordsPage = () => {
 
       saveNewWallet({ wallet, walletName, password })
 
-      posthog?.capture('New wallet imported', { wallet_name_length: walletName.length })
+      posthog.capture('New wallet imported', { wallet_name_length: walletName.length })
 
       discoverAndSaveUsedAddresses({ mnemonic: wallet.mnemonic, skipIndexes: [0], enableLoading: false })
       onButtonNext()

--- a/src/pages/NewWallet/WalletWelcomePage.tsx
+++ b/src/pages/NewWallet/WalletWelcomePage.tsx
@@ -71,7 +71,7 @@ const WalletWelcomePage = () => {
         label: `Address ${defaultAddress.group}`
       })
 
-      posthog?.capture('Generated one address per group on wallet creation')
+      posthog.capture('Generated one address per group on wallet creation')
     }
 
     navigate('/wallet/overview')

--- a/src/pages/UnlockedWallet/AddressesPage/AdvancedOperationsSideModal.tsx
+++ b/src/pages/UnlockedWallet/AddressesPage/AdvancedOperationsSideModal.tsx
@@ -46,22 +46,22 @@ const AdvancedOperationsSideModal = (props: AdvancedOperationsSideModal) => {
 
   const handleOneAddressPerGroupClick = () => {
     isPassphraseUsed ? generateAndSaveOneAddressPerGroup() : setIsAddressesGenerationModalOpen(true)
-    posthog?.capture('Advanced operation to generate one address per group clicked')
+    posthog.capture('Advanced operation to generate one address per group clicked')
   }
 
   const handleDiscoverAddressesClick = () => {
     discoverAndSaveUsedAddresses()
-    posthog?.capture('Advanced operation to discover addresses clicked')
+    posthog.capture('Advanced operation to discover addresses clicked')
   }
 
   const handleConsolidationClick = () => {
     setIsConsolidationModalOpen(true)
-    posthog?.capture('Advanced operation to consolidate UTXOs clicked')
+    posthog.capture('Advanced operation to consolidate UTXOs clicked')
   }
 
   const handleTellUsIdeasClick = () => {
     openInWebBrowser(links.discord)
-    posthog?.capture('Advanced operation to share ideas clicked')
+    posthog.capture('Advanced operation to share ideas clicked')
   }
 
   return (

--- a/src/pages/UnlockedWallet/UnlockedWalletLayout.tsx
+++ b/src/pages/UnlockedWallet/UnlockedWalletLayout.tsx
@@ -94,7 +94,7 @@ const UnlockedWalletLayout = ({ children, title, className }: UnlockedWalletLayo
   const refreshAddressesData = () => {
     dispatch(syncAddressesData())
 
-    posthog?.capture('Refreshed data')
+    posthog.capture('Refreshed data')
   }
 
   return (

--- a/src/storage/addresses/addressesActions.ts
+++ b/src/storage/addresses/addressesActions.ts
@@ -21,6 +21,7 @@ import { explorer } from '@alephium/web3'
 import { createAction, createAsyncThunk } from '@reduxjs/toolkit'
 import dayjs from 'dayjs'
 import { chunk } from 'lodash'
+import { posthog } from 'posthog-js'
 
 import {
   fetchAddressesData,
@@ -76,6 +77,7 @@ export const syncAddressesData = createAsyncThunk<
   try {
     return await fetchAddressesData(addresses)
   } catch (e) {
+    posthog.capture('Error - Synching address data')
     return rejectWithValue({
       text: getHumanReadableError(e, i18n.t("Encountered error while synching your addresses' data.")),
       type: 'alert'
@@ -172,6 +174,7 @@ export const syncAddressesHistoricBalances = createAsyncThunk(
         }
       } catch (e) {
         console.error('Could not parse amount history data', e)
+        posthog.capture('Error - Could not parse amount history data')
       }
 
       addressesBalances.push({

--- a/src/storage/addresses/addressesActions.ts
+++ b/src/storage/addresses/addressesActions.ts
@@ -77,7 +77,7 @@ export const syncAddressesData = createAsyncThunk<
   try {
     return await fetchAddressesData(addresses)
   } catch (e) {
-    posthog.capture('Error - Synching address data')
+    posthog.capture('Error', { message: 'Synching address data' })
     return rejectWithValue({
       text: getHumanReadableError(e, i18n.t("Encountered error while synching your addresses' data.")),
       type: 'alert'
@@ -174,7 +174,7 @@ export const syncAddressesHistoricBalances = createAsyncThunk(
         }
       } catch (e) {
         console.error('Could not parse amount history data', e)
-        posthog.capture('Error - Could not parse amount history data')
+        posthog.capture('Error', { message: 'Could not parse amount history data' })
       }
 
       addressesBalances.push({

--- a/src/storage/assets/assetsActions.ts
+++ b/src/storage/assets/assetsActions.ts
@@ -20,6 +20,7 @@ import { Asset } from '@alephium/sdk'
 import { TokenList } from '@alephium/token-list'
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { omit } from 'lodash'
+import posthog from 'posthog-js'
 
 import client, { exponentialBackoffFetchRetry } from '@/api/client'
 import { RootState } from '@/storage/store'
@@ -40,6 +41,7 @@ export const syncNetworkTokensInfo = createAsyncThunk('assets/syncNetworkTokensI
       metadata = (await response.json()) as TokenList
     } catch (e) {
       console.warn('No metadata for network ID ', state.network.settings.networkId)
+      posthog.capture(`Error - No metadata for network ID ${state.network.settings.networkId}`)
     }
   }
 
@@ -79,6 +81,7 @@ export const syncUnknownTokensInfo = createAsyncThunk(
         }
       } catch (e) {
         console.error(e)
+        posthog.capture('Error - Syncing unknown tokens info')
       }
     }
 

--- a/src/storage/assets/assetsActions.ts
+++ b/src/storage/assets/assetsActions.ts
@@ -41,7 +41,7 @@ export const syncNetworkTokensInfo = createAsyncThunk('assets/syncNetworkTokensI
       metadata = (await response.json()) as TokenList
     } catch (e) {
       console.warn('No metadata for network ID ', state.network.settings.networkId)
-      posthog.capture(`Error - No metadata for network ID ${state.network.settings.networkId}`)
+      posthog.capture('Error', { message: `No metadata for network ID ${state.network.settings.networkId}` })
     }
   }
 
@@ -81,7 +81,7 @@ export const syncUnknownTokensInfo = createAsyncThunk(
         }
       } catch (e) {
         console.error(e)
-        posthog.capture('Error - Syncing unknown tokens info')
+        posthog.capture('Error', { message: 'Syncing unknown tokens info' })
       }
     }
 

--- a/src/storage/encryptedPersistentStorage.ts
+++ b/src/storage/encryptedPersistentStorage.ts
@@ -32,7 +32,7 @@ export class PersistentEncryptedStorage extends StatelessPersistentEncryptedStor
     } catch (e) {
       console.error(e)
       store.dispatch(loadingDataFromLocalStorageFailed())
-      posthog.capture('Error - Could not load data from local storage')
+      posthog.capture('Error', { message: 'Could not load data from local storage' })
     }
   }
 
@@ -42,7 +42,7 @@ export class PersistentEncryptedStorage extends StatelessPersistentEncryptedStor
     } catch (e) {
       console.error(e)
       store.dispatch(storingDataToLocalStorageFailed())
-      posthog.capture('Error - Could not store data from local storage')
+      posthog.capture('Error', { message: 'Could not store data from local storage' })
     }
   }
 }

--- a/src/storage/encryptedPersistentStorage.ts
+++ b/src/storage/encryptedPersistentStorage.ts
@@ -16,6 +16,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import posthog from 'posthog-js'
+
 import { loadingDataFromLocalStorageFailed, storingDataToLocalStorageFailed } from '@/storage/global/globalActions'
 import {
   EncryptedStorageProps,
@@ -30,6 +32,7 @@ export class PersistentEncryptedStorage extends StatelessPersistentEncryptedStor
     } catch (e) {
       console.error(e)
       store.dispatch(loadingDataFromLocalStorageFailed())
+      posthog.capture('Error - Could not load data from local storage')
     }
   }
 
@@ -39,6 +42,7 @@ export class PersistentEncryptedStorage extends StatelessPersistentEncryptedStor
     } catch (e) {
       console.error(e)
       store.dispatch(storingDataToLocalStorageFailed())
+      posthog.capture('Error - Could not store data from local storage')
     }
   }
 }

--- a/src/storage/settings/settingsPersistentStorage.ts
+++ b/src/storage/settings/settingsPersistentStorage.ts
@@ -17,6 +17,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { clone, merge } from 'lodash'
+import posthog from 'posthog-js'
 
 import { NetworkPreset } from '@/types/network'
 import { NetworkSettings, Settings } from '@/types/settings'
@@ -73,6 +74,7 @@ class SettingsStorage {
       return merge({}, defaultSettings, parsedSettings)
     } catch (e) {
       console.error(e)
+      posthog.capture('Error - Parsing stored settings')
       return defaultSettings // Fallback to default settings if something went wrong
     }
   }

--- a/src/storage/settings/settingsPersistentStorage.ts
+++ b/src/storage/settings/settingsPersistentStorage.ts
@@ -74,7 +74,7 @@ class SettingsStorage {
       return merge({}, defaultSettings, parsedSettings)
     } catch (e) {
       console.error(e)
-      posthog.capture('Error - Parsing stored settings')
+      posthog.capture('Error', { message: 'Parsing stored settings' })
       return defaultSettings // Fallback to default settings if something went wrong
     }
   }

--- a/src/storage/settings/settingsSlice.ts
+++ b/src/storage/settings/settingsSlice.ts
@@ -28,6 +28,7 @@ import 'dayjs/locale/vi'
 
 import { createListenerMiddleware, createSlice, isAnyOf } from '@reduxjs/toolkit'
 import dayjs from 'dayjs'
+import posthog from 'posthog-js'
 
 import i18next from '@/i18n'
 import { localStorageDataMigrated } from '@/storage/global/globalActions'
@@ -136,6 +137,7 @@ settingsListenerMiddleware.startListening({
         await i18next.changeLanguage(settings.language)
       } catch (e) {
         console.error(e)
+        posthog.capture('Error - Changing language')
       } finally {
         dispatch(languageChangeFinished())
       }

--- a/src/storage/settings/settingsSlice.ts
+++ b/src/storage/settings/settingsSlice.ts
@@ -137,7 +137,7 @@ settingsListenerMiddleware.startListening({
         await i18next.changeLanguage(settings.language)
       } catch (e) {
         console.error(e)
-        posthog.capture('Error - Changing language')
+        posthog.capture('Error', { message: 'Changing language' })
       } finally {
         dispatch(languageChangeFinished())
       }

--- a/src/storage/transactions/transactionsActions.ts
+++ b/src/storage/transactions/transactionsActions.ts
@@ -45,7 +45,7 @@ export const fetchTransactionsCsv = createAsyncThunk<string, CsvExportQueryParam
     try {
       return await fetchCsv(queryParams)
     } catch (e) {
-      posthog.capture('Error - Fetching CSV')
+      posthog.capture('Error', { message: 'Fetching CSV' })
       return rejectWithValue({
         text: getHumanReadableError(e, i18n.t('Encountered error while exporting your transactions.')),
         type: 'alert'

--- a/src/storage/transactions/transactionsActions.ts
+++ b/src/storage/transactions/transactionsActions.ts
@@ -18,6 +18,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import { getHumanReadableError } from '@alephium/sdk'
 import { createAction, createAsyncThunk } from '@reduxjs/toolkit'
+import posthog from 'posthog-js'
 
 import { fetchCsv } from '@/api/transactions'
 import i18n from '@/i18n'
@@ -44,6 +45,7 @@ export const fetchTransactionsCsv = createAsyncThunk<string, CsvExportQueryParam
     try {
       return await fetchCsv(queryParams)
     } catch (e) {
+      posthog.capture('Error - Fetching CSV')
       return rejectWithValue({
         text: getHumanReadableError(e, i18n.t('Encountered error while exporting your transactions.')),
         type: 'alert'

--- a/src/storage/transactions/transactionsStorageUtils.ts
+++ b/src/storage/transactions/transactionsStorageUtils.ts
@@ -34,6 +34,6 @@ export const restorePendingTransactions = () => {
   } catch (e) {
     console.error(e)
     store.dispatch(loadingPendingTransactionsFailed())
-    posthog.capture('Error - Restoringi pending transactions')
+    posthog.capture('Error', { message: 'Restoring pending transactions' })
   }
 }

--- a/src/storage/transactions/transactionsStorageUtils.ts
+++ b/src/storage/transactions/transactionsStorageUtils.ts
@@ -16,6 +16,8 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import posthog from 'posthog-js'
+
 import { getEncryptedStoragePropsFromActiveWallet } from '@/storage/encryptedPersistentStorage'
 import { store } from '@/storage/store'
 import PendingTransactionsStorage from '@/storage/transactions/pendingTransactionsPersistentStorage'
@@ -32,5 +34,6 @@ export const restorePendingTransactions = () => {
   } catch (e) {
     console.error(e)
     store.dispatch(loadingPendingTransactionsFailed())
+    posthog.capture('Error - Restoringi pending transactions')
   }
 }

--- a/src/storage/wallets/walletPersistentStorage.ts
+++ b/src/storage/wallets/walletPersistentStorage.ts
@@ -19,6 +19,7 @@ along with the library. If not, see <http://www.gnu.org/licenses/>.
 import { Wallet, walletOpen } from '@alephium/sdk'
 import { orderBy } from 'lodash'
 import { nanoid } from 'nanoid'
+import posthog from 'posthog-js'
 
 import { StoredWallet, UnencryptedWallet } from '@/types/wallet'
 
@@ -49,6 +50,7 @@ class WalletStorage {
           wallets.push(wallet)
         } catch (e) {
           console.error(e)
+          posthog.capture('Error - Parsing stored wallet data')
           continue
         }
       }

--- a/src/storage/wallets/walletPersistentStorage.ts
+++ b/src/storage/wallets/walletPersistentStorage.ts
@@ -50,7 +50,7 @@ class WalletStorage {
           wallets.push(wallet)
         } catch (e) {
           console.error(e)
-          posthog.capture('Error - Parsing stored wallet data')
+          posthog.capture('Error', { message: 'Parsing stored wallet data' })
           continue
         }
       }


### PR DESCRIPTION
@mvaivre I purposefully did not capture the actual error message in the spirit of preserving user privacy. We don't know what info the error messages might include. Some could be PII. To respect our decision to not store any user data, I simply capture generic errors that will give us a hint as to where there might be a problem so that we can identify it outselves.

I did a global search for `catch (e) {` and capture an error.