### PR TITLE
Add More Fiat Currency option on Alephium Wallet

### DIFF
--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -87,4 +87,4 @@ declare module 'styled-components' {
   }
 }
 
-export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' 
+export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY'

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -87,4 +87,4 @@ declare module 'styled-components' {
   }
 }
 
-export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB'| 'TRY' 
+export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' 

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -40,7 +40,7 @@ export interface Settings {
   network: NetworkSettings
 }
 
-export type Language = 'en-US' | 'fr-FR' | 'de-DE' | 'vi-VN' | 'pt-PT' | 'ru-RU' | 'bg-BG' | 'id-ID' | 'tr-TR' 
+export type Language = 'en-US' | 'fr-FR' | 'de-DE' | 'vi-VN' | 'pt-PT' | 'ru-RU' | 'bg-BG' | 'id-ID' | 'tr-TR'
 
 export type ThemeType = 'light' | 'dark'
 
@@ -87,4 +87,4 @@ declare module 'styled-components' {
   }
 }
 
-export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB'| 'TRY'   
+export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB'| 'TRY' 

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -40,7 +40,7 @@ export interface Settings {
   network: NetworkSettings
 }
 
-export type Language = 'en-US' | 'fr-FR' | 'de-DE' | 'vi-VN' | 'pt-PT' | 'ru-RU' | 'bg-BG' | 'id-ID'
+export type Language = 'en-US' | 'fr-FR' | 'de-DE' | 'vi-VN' | 'pt-PT' | 'ru-RU' | 'bg-BG' | 'id-ID' | 'tr-TR' 
 
 export type ThemeType = 'light' | 'dark'
 
@@ -87,4 +87,4 @@ declare module 'styled-components' {
   }
 }
 
-export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD'
+export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB'| 'TRY'   

--- a/src/utils/currencies.ts
+++ b/src/utils/currencies.ts
@@ -45,6 +45,21 @@ export const currencies: Record<Currency, CurrencyData> = {
     ticker: 'GBP',
     symbol: '£'
   },
+  TRY: {
+    name: 'Turkish Lira',
+    ticker: 'TRY',
+    symbol: '₺'
+  },
+  VND: {
+    name: 'Vietnamese Dong',
+    ticker: 'VND',
+    symbol: '₫'
+  },
+  RUB: {
+    name: 'Russian Ruble',
+    ticker: 'RUB',
+    symbol: '₽'
+  },
   USD: {
     name: 'United States Dollar',
     ticker: 'USD',


### PR DESCRIPTION
Hello, i add three fiat currencies in to Alph Wallet. 
1. Turkiye Lira
2. Russian Ruble
3. Vietnamese Dong

Thanks You So Much!