### PR TITLE
Add More Fiat Currency options on Alephium Wallet 

### DIFF
--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -53,7 +53,7 @@ export type ThemeType = 'light' | 'dark'
 
 export type ThemeSettings = ThemeType | 'system'
 
-export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' | 'CNY' | 'CAD' | 'MYR' | 'SAR' | 'HKD'
+export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY'
 
 declare module 'styled-components' {
   export interface DefaultTheme {

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -53,7 +53,7 @@ export type ThemeType = 'light' | 'dark'
 
 export type ThemeSettings = ThemeType | 'system'
 
-export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD'
+export type Currency = 'CHF' | 'IDR' | 'GBP' | 'EUR' | 'USD' | 'VND' | 'RUB' | 'TRY' | 'CNY' | 'CAD' | 'MYR' | 'SAR' | 'HKD'
 
 declare module 'styled-components' {
   export interface DefaultTheme {

--- a/src/utils/currencies.ts
+++ b/src/utils/currencies.ts
@@ -64,30 +64,5 @@ export const currencies: Record<Currency, CurrencyData> = {
     name: 'Russian Ruble',
     ticker: 'RUB',
     symbol: '₽'
-  },
-  CNY: {
-    name: 'Chinese Yuan',
-    ticker: 'CNY',
-    symbol: '¥'
-  },
-  CAD: {
-    name: 'Canadian Dollar',
-    ticker: 'CAD',
-    symbol: '$'
-  },
-  HKD: {
-    name: 'Hongkong Dollar',
-    ticker: 'HKD',
-    symbol: 'HK$'
-  },
-  MYR: {
-    name: 'Malaysian Ringgit',
-    ticker: 'MYR',
-    symbol: 'RM'
-  },
-  SAR: {
-    name: 'Saudi Riyal',
-    ticker: 'SAR',
-    symbol: 'SAR'
   }
 }

--- a/src/utils/currencies.ts
+++ b/src/utils/currencies.ts
@@ -49,5 +49,45 @@ export const currencies: Record<Currency, CurrencyData> = {
     name: 'United States Dollar',
     ticker: 'USD',
     symbol: '$'
+  },
+  TRY: {
+    name: 'Turkish Lira',
+    ticker: 'TRY',
+    symbol: '₺'
+  },
+  VND: {
+    name: 'Vietnamese Dong',
+    ticker: 'VND',
+    symbol: '₫'
+  },
+  RUB: {
+    name: 'Russian Ruble',
+    ticker: 'RUB',
+    symbol: '₽'
+  },
+  CNY: {
+    name: 'Chinese Yuan',
+    ticker: 'CNY',
+    symbol: '¥'
+  },
+  CAD: {
+    name: 'Canadian Dollar',
+    ticker: 'CAD',
+    symbol: '$'
+  },
+  HKD: {
+    name: 'Hongkong Dollar',
+    ticker: 'HKD',
+    symbol: 'HK$'
+  },
+  MYR: {
+    name: 'Malaysian Ringgit',
+    ticker: 'MYR',
+    symbol: 'RM'
+  },
+  SAR: {
+    name: 'Saudi Riyal',
+    ticker: 'SAR',
+    symbol: 'SAR'
   }
 }


### PR DESCRIPTION
Hello, i add three fiat currencies in to Alph Wallet.

1. Turkiye Lira
2. Russian Ruble
3. Vietnamese Dong
Thanks You So Much!