### PR TITLE
Use latest price as last data point in chart

### DIFF
--- a/src/pages/UnlockedWallet/OverviewPage/AmountsOverviewPanel.tsx
+++ b/src/pages/UnlockedWallet/OverviewPage/AmountsOverviewPanel.tsx
@@ -83,7 +83,8 @@ const AmountsOverviewPanel: FC<AmountsOverviewPanelProps> = ({ className, addres
   const totalBalance = addresses.reduce((acc, address) => acc + BigInt(address.balance), BigInt(0))
   const totalAvailableBalance = addresses.reduce((acc, address) => acc + getAvailableBalance(address), BigInt(0))
   const totalLockedBalance = addresses.reduce((acc, address) => acc + BigInt(address.lockedBalance), BigInt(0))
-  const totalAmountWorth = calculateAmountWorth(totalBalance, price ?? 0)
+  const totalAmountWorth =
+    price !== undefined && !stateUninitialized ? calculateAmountWorth(totalBalance, price) : undefined
   const balanceInFiat = worth ?? totalAmountWorth
 
   const isOnline = network.status === 'online'
@@ -108,7 +109,7 @@ const AmountsOverviewPanel: FC<AmountsOverviewPanelProps> = ({ className, addres
                   stateUninitialized ||
                   (hasHistoricBalances && worthInBeginningOfChart === undefined) ? (
                     <SkeletonLoader height="18px" width="70px" style={{ marginBottom: 6 }} />
-                  ) : hasHistoricBalances && worthInBeginningOfChart ? (
+                  ) : hasHistoricBalances && worthInBeginningOfChart && totalAmountWorth !== undefined ? (
                     <DeltaPercentage initialValue={worthInBeginningOfChart} latestValue={totalAmountWorth} />
                   ) : null}
                 </FiatDeltaPercentage>
@@ -173,7 +174,9 @@ const AmountsOverviewPanel: FC<AmountsOverviewPanelProps> = ({ className, addres
 
       <ChartOuterContainer
         variants={chartAnimationVariants}
-        animate={showChart && hasHistoricBalances && !discreetMode ? 'shown' : 'hidden'}
+        animate={
+          showChart && hasHistoricBalances && !discreetMode && totalAmountWorth !== undefined ? 'shown' : 'hidden'
+        }
       >
         <ChartInnerContainer animate={{ opacity: discreetMode ? 0 : 1 }} transition={{ duration: 0.5 }}>
           <HistoricWorthChart

--- a/src/storage/assets/priceApiSlice.ts
+++ b/src/storage/assets/priceApiSlice.ts
@@ -51,9 +51,18 @@ export const priceApi = createApi({
         const { prices } = response
         const today = dayjs().format(CHART_DATE_FORMAT)
 
-        return prices
-          .filter(([date]) => dayjs(date).format(CHART_DATE_FORMAT) !== today)
-          .map(([date, price]) => ({ date: dayjs(date).format(CHART_DATE_FORMAT), price }))
+        return prices.reduce((acc, [date, price]) => {
+          const itemDate = dayjs(date).format(CHART_DATE_FORMAT)
+          const isDuplicatedItem = !!acc.find(({ date }) => dayjs(date).format(CHART_DATE_FORMAT) === itemDate)
+
+          if (!isDuplicatedItem && itemDate !== today)
+            acc.push({
+              date: itemDate,
+              price
+            })
+
+          return acc
+        }, [] as HistoricalPriceResult[])
       }
     })
   })

--- a/src/storage/assets/priceApiSlice.ts
+++ b/src/storage/assets/priceApiSlice.ts
@@ -47,8 +47,14 @@ export const priceApi = createApi({
     }),
     getHistoricalPrice: builder.query<HistoricalPriceResult[], HistoricalPriceQueryParams>({
       query: ({ currency, days }) => `/coins/alephium/market_chart?vs_currency=${currency.toLowerCase()}&days=${days}`,
-      transformResponse: (response: { prices: number[][] }) =>
-        response.prices.map((p) => ({ date: dayjs(p[0]).format(CHART_DATE_FORMAT), price: p[1] }))
+      transformResponse: (response: { prices: number[][] }) => {
+        const { prices } = response
+        const today = dayjs().format(CHART_DATE_FORMAT)
+
+        return prices
+          .filter(([date]) => dayjs(date).format(CHART_DATE_FORMAT) !== today)
+          .map(([date, price]) => ({ date: dayjs(date).format(CHART_DATE_FORMAT), price }))
+      }
     })
   })
 })


### PR DESCRIPTION
Closes #774

The problem was that the last item of the response of the `getHistoricalPrice` endpoint was slightly different than the latest price from the `getPrice` endpoint. The fix removes today's price received from the 1st endpoint and adds the one from the 2nd.